### PR TITLE
css now returns a className instead of a function

### DIFF
--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -12,9 +12,9 @@ jest.mock("../core/parser/get-css", () => ({
 
 describe("styled", () => {
     it("should return the className for vanilla", () => {
-        const vanilla = styled("")`css`({});
+        const vanilla = styled("")`css`;
 
-        expect(getCss).toHaveBeenCalledWith(["css"], [], {});
+        expect(getCss).toHaveBeenCalledWith(["css"], [], undefined);
         expect(getClassNameForCss).toHaveBeenCalledWith("getCss");
         
         expect(vanilla).toEqual('getClassNameForCss');

--- a/src/styled.js
+++ b/src/styled.js
@@ -33,5 +33,5 @@ export const styled = tag =>
         })
       );
     };
-    return !tag ? processStyles() : processStyles;
+    return tag ? processStyles : processStyles();
   };

--- a/src/styled.js
+++ b/src/styled.js
@@ -5,7 +5,7 @@ let h;
 
 /**
  * Sets custom pragma to be used in contexts
- * @param {function} val 
+ * @param {function} val
  */
 export const setPragma = val => (h = val);
 
@@ -14,16 +14,24 @@ export const setPragma = val => (h = val);
  * @param {String} tag DOM tagName
  * @return {Function}
  */
-export const styled = tag => (str, ...defs) => {  
-  const processStyles = props => {
-    const className = getClassNameForCss(getCss(str, defs, props));
+export const styled = tag =>
+  function() {
+    const args = [].slice.call(arguments);
+    const processStyles = props => {
+      const className = getClassNameForCss(
+        getCss(args[0], args.slice(1), props)
+      );
 
-    // To be used for 'vanilla'
-    if (!h || !tag) return className;
+      // To be used for 'vanilla'
+      if (!h || !tag) return className;
 
-    return h(tag, Object.assign({}, props, {
-      className: (props && props.className ? props.className + " " : "") + className
-    }));
-  }
-  return !tag ? processStyles() : processStyles
-};
+      return h(
+        tag,
+        Object.assign({}, props, {
+          className:
+            (props && props.className ? props.className + " " : "") + className
+        })
+      );
+    };
+    return !tag ? processStyles() : processStyles;
+  };

--- a/src/styled.js
+++ b/src/styled.js
@@ -14,7 +14,8 @@ export const setPragma = val => (h = val);
  * @param {String} tag DOM tagName
  * @return {Function}
  */
-export const styled = tag => (str, ...defs) => props => {
+export const styled = tag => (str, ...defs) => {  
+  const processStyles = props => {
     const className = getClassNameForCss(getCss(str, defs, props));
 
     // To be used for 'vanilla'
@@ -23,4 +24,6 @@ export const styled = tag => (str, ...defs) => props => {
     return h(tag, Object.assign({}, props, {
       className: (props && props.className ? props.className + " " : "") + className
     }));
+  }
+  return !tag ? processStyles() : processStyles
 };


### PR DESCRIPTION
Implemented the change for CSS we discussed. styled itself now knows how to handle the "no tag" situation. File size is as follows:

![image](https://user-images.githubusercontent.com/32208506/53366224-5bf6be00-3943-11e9-8272-d8475a8e38ff.png)
