### PR TITLE
Object style poc

### DIFF
--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -36,6 +36,6 @@ describe("styled", () => {
 
     it("object style notation", () => {
         const Comp = styled("tag")({ foo: 1 })({});
-        expect(getClassNameForCss).toBeCalledWith({ foo: 1 });
+        expect(getClassNameForCss).toBeCalledWith("getCss", true);
     })
 });

--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -33,4 +33,9 @@ describe("styled", () => {
         const Comp = styled("tag")`css`({});
         expect(fn).toBeCalled();
     });
+
+    it("object style notation", () => {
+        const Comp = styled("tag")({ foo: 1 })({});
+        expect(getClassNameForCss).toBeCalledWith({ foo: 1 });
+    })
 });

--- a/src/core/__tests__/hush.test.js
+++ b/src/core/__tests__/hush.test.js
@@ -11,8 +11,8 @@ describe("hush", () => {
     it("object", () => {
         const val = { foo: 1 };
 
-        expect(hush(val)).toEqual(747);
-        expect(hush(val)).toEqual(747);
+        expect(hush(val)).toEqual("g0747");
+        expect(hush(val)).toEqual("g0747");
     });
 
 });

--- a/src/core/__tests__/hush.test.js
+++ b/src/core/__tests__/hush.test.js
@@ -8,4 +8,11 @@ describe("hush", () => {
         expect(hush(val)).toEqual(638);
     });
 
+    it("object", () => {
+        const val = { foo: 1 };
+
+        expect(hush(val)).toEqual(747);
+        expect(hush(val)).toEqual(747);
+    });
+
 });

--- a/src/core/hush.js
+++ b/src/core/hush.js
@@ -5,7 +5,7 @@
  * @returns {String}
  */
 export const hush = str =>
-  (str.big ? str : JSON.stringify(str)).split("").reduce(
+  "g0" +(str.big ? str : JSON.stringify(str)).split("").reduce(
     (out, c) => out + c.charCodeAt(0),
     0
   );

--- a/src/core/hush.js
+++ b/src/core/hush.js
@@ -5,7 +5,7 @@
  * @returns {String}
  */
 export const hush = str =>
-  str.split("").reduce(
+  (str.big ? str : JSON.stringify(str)).split("").reduce(
     (out, c) => out + c.charCodeAt(0),
     0
   );

--- a/src/core/parser/__tests__/parse.test.js
+++ b/src/core/parser/__tests__/parse.test.js
@@ -100,4 +100,15 @@ describe("parse", () => {
             "@keyframes App-logo-spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}"
         ].join(""));
     });
+
+    describe("object style notation", () => {
+        it("should work", () => {
+            expect(parse(".object", {
+                "text-align": "center",
+                "padding": 1 + "px"
+            })).toEqual([
+                ".object{text-align:center;padding:1px;}"
+            ].join(""))
+        })
+    });
 });

--- a/src/core/parser/parse.js
+++ b/src/core/parser/parse.js
@@ -63,7 +63,7 @@ const compile = (obj, paren, wrapper) => {
 export const parse = (hash, val) => {
   // Kick the compilation
   return compile(
-    astish(val),
+    val.big ? astish(val) : val,
     hash
   );
 };

--- a/src/core/style/get-class-name.js
+++ b/src/core/style/get-class-name.js
@@ -8,9 +8,7 @@ import { parse } from "../parser/parse";
  * @return {String}
  */
 export const getClassNameForCss = compiled => {
-  const hash = "g0" + hush(
-      compiled.replace(/\s|\n/gm, "")
-    ).toString(8);
+  const hash = "g0" + hush(compiled).toString(8);
   const parsed = parse("." + hash, compiled);
   
     // This methods adds or updates the new style

--- a/src/core/style/sheet.js
+++ b/src/core/style/sheet.js
@@ -20,31 +20,33 @@ export const flush = () => {
  */
 export const add = (hash, css) => {
 
-    // If this is already present just stop
-    if (styles[hash] == css) {
-      return;
-    }
-  
-    // Keep the hash and the value in _cache_
-    styles[hash] = css;
-  
-    // If we're no the client
-    if (typeof document != "undefined") {
-      if (!sheet || !sheet.parentElement) {
-        sheet = document.querySelector("style[" + SHEET_ID + "]");
-  
-        if (!sheet) {
-          sheet = document.createElement("style");
-          sheet.setAttribute(SHEET_ID, "");
-          document.head.appendChild(sheet);
-        }
+  // If this is already present just stop
+  if (styles[hash] == css) {
+    return;
+  }
+
+  // Keep the hash and the value in _cache_
+  styles[hash] = css;
+
+  // If we're no the client
+  try {
+    if (!sheet || !sheet.parentElement) {
+      sheet = document.querySelector("style[" + SHEET_ID + "]");
+
+      if (!sheet) {
+        sheet = document.createElement("style");
+        sheet.setAttribute(SHEET_ID, "");
+        document.head.appendChild(sheet);
       }
-  
-      if (!sheet.firstChild) {
-        sheet.appendChild(document.createTextNode(""));
-      }
-  
-      // Append the css into the style sheet
-      sheet.firstChild.data += css;
     }
-  };
+
+    if (!sheet.firstChild) {
+      sheet.appendChild(document.createTextNode(""));
+    }
+
+    // Append the css into the style sheet
+    sheet.firstChild.data += css;
+  } catch (e) {
+    // Just ignore it, we're on the server
+  }
+};

--- a/src/styled.js
+++ b/src/styled.js
@@ -19,7 +19,7 @@ export const styled = tag =>
     const args = [].slice.call(arguments);
     const processStyles = props => {
       const className = getClassNameForCss(
-        getCss(args[0], args.slice(1), props)
+        args[0].map ? getCss(args[0], args.slice(1), props) : args[0]
       );
 
       // To be used for 'vanilla'


### PR DESCRIPTION
This is addressing the support for object styled from #14 

```js
import { css, styled } from 'goober';

const Foo = css({
  "text-align": "center",
  padding: 0
});

// or with styled

const Baz = styled("button")({
  background: "red",
 "&:active": {
    "color": "blue"
  }
});
```

`+18B`