### PR TITLE
Create a new object and assign props to it for a new extensible object

### DIFF
--- a/src/styled.js
+++ b/src/styled.js
@@ -14,7 +14,7 @@ function styled(tag) {
     const _args = arguments;
 
     return function Styled(props) {
-      _ctx.p = props ? Object.assign({}, props) : {};
+      _ctx.p = Object.assign({}, props);
       _ctx.o = /\s*go[0-9]+/g.test(_ctx.p.className);
       _ctx.p.className = css.apply(_ctx, _args) + (_ctx.p.className ? " " + _ctx.p.className : "");
 

--- a/src/styled.js
+++ b/src/styled.js
@@ -10,11 +10,11 @@ const setPragma = pragma => (h = pragma);
 function styled(tag) {
   const _ctx = this || {};
 
-  return function() {
+  return function () {
     const _args = arguments;
 
     return function Styled(props) {
-      _ctx.p = props || {};
+      _ctx.p = props ? Object.assign({}, props) : {};
       _ctx.o = /\s*go[0-9]+/g.test(_ctx.p.className);
       _ctx.p.className = css.apply(_ctx, _args) + (_ctx.p.className ? " " + _ctx.p.className : "");
 


### PR DESCRIPTION
When using the `styled(tag)` function, the props passed to the component are assigned to `_ctx.p` and new properties are assigned to this object. However, `_ctx.p` is unable to be extended, due to `preventExtensions`. This results in an error `cannot add property className, object is not extensible`.

Creating a new object and assigning the props to it, will result in an extensible object again.