### PR TITLE
update readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import { styled, setPragma } from "goober";
 // Should be called here, and just once
 setPragma(h);
 
-const Icon = styled("i")`
+const Icon = styled("span")`
   display: flex;
   flex: 1;
   color: red;


### PR DESCRIPTION
This is a minor change in the doc, specifically in the main example:
- replace `styled("i")`with `styled("span")`;

Quite often we see icons being created with `<i>` or `<span>`, but if we dive deep in semantics, `<i>` tags aren't good for icons since they (icons) aren't _alternate voices_ or _terms_, they're only visual resources :tada: