### PR TITLE
Add support for forwardRef

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -6,6 +6,7 @@ describe("goober", () => {
       "css",
       "extractCss",
       "glob",
+      "setForwardRef",
       "setPragma",
       "styled"
     ]);

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -1,11 +1,13 @@
 import { h, render } from 'preact';
-import { setPragma, styled } from '../index';
+import { forwardRef } from 'preact/compat';
+import { setPragma, setForwardRef, styled } from '../index';
 import { extractCss } from '../core/update';
 
 describe("integrations", () => {
 
     it("preact", () => {
         setPragma(h);
+        setForwardRef(forwardRef);
 
         const target = document.createElement('div');
 
@@ -21,9 +23,14 @@ describe("integrations", () => {
             color: ${props.color};
         `);
 
+        let element;
+
         render(
             <div>
-                <Box />
+                <Box
+                    ref={el => { element = el; }}
+                    className="original-cls"
+                />
                 <BoxWithColor color={'red'} />
                 <BoxWithColorFn color={'red'} />
             </div>
@@ -32,6 +39,8 @@ describe("integrations", () => {
         );
 
         expect(extractCss()).toEqual(' .go2155{color:red;}');
+        expect(element.tagName).toBe('DIV');
+        expect(element.className).toBe('go2155 original-cls');
     });
 
 });

--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -18,10 +18,10 @@ describe("styled", () => {
   it("setPragma", () => {
     const pragma = jest.fn();
 
-    expect(() => styled()()()).toThrow();
+    expect(() => styled("div")()()).toThrow();
 
     setPragma(pragma);
-    styled()()();
+    styled("div")()();
 
     expect(pragma).toBeCalled();
 
@@ -30,7 +30,7 @@ describe("styled", () => {
 
   it("args", () => {
     const _h = jest.fn().mockReturnValue("h()");
-    const p = { bar: 1};
+    const p = { bar: 1 };
     setPragma(_h);
 
     expect(styled("tag")`foo: 1`(p)).toEqual("h()");

--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -1,5 +1,5 @@
 import { h, render } from 'preact';
-import { styled, setPragma } from "../styled";
+import { styled, setPragma, setForwardRef } from "../styled";
 import { css } from "../css";
 
 jest.mock("../css", () => ({
@@ -26,6 +26,20 @@ describe("styled", () => {
     expect(pragma).toBeCalled();
 
     setPragma(undefined);
+  });
+
+  it("setForwardRef", () => {
+    const forwardRef = jest.fn(x => x);
+    const pragma = jest.fn();
+
+    setPragma(pragma);
+    setForwardRef(forwardRef);
+    styled("div")()();
+
+    expect(forwardRef).toBeCalled();
+
+    setPragma(undefined);
+    setForwardRef(undefined);
   });
 
   it("args", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export { styled, setPragma } from "./styled";
+export { styled, setPragma, setForwardRef } from "./styled";
 export { extractCss } from "./core/update";
 export { css, glob } from "./css";

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,7 +1,9 @@
 import { css } from "./css";
 
 let h;
-const setPragma = pragma => (h = pragma);
+let forwardRef;
+const setPragma = pragma => { h = pragma };
+const setForwardRef = fn => { forwardRef = fn };
 
 /**
  * Styled function
@@ -13,19 +15,23 @@ function styled(tag) {
   return function () {
     const _args = arguments;
 
-    return function Styled(props) {
+    function Styled(props, ref) {
       const _props = _ctx.p = Object.assign({}, props);
       const _previousClassName = _props.className;
 
       _ctx.o = /\s*go[0-9]+/g.test(_previousClassName);
       _props.className = css.apply(_ctx, _args) + (_previousClassName ? " " + _previousClassName : "");
+      if (forwardRef) {
+        _props.ref = ref;
+      }
 
       return h(
         tag,
         _props
       );
     };
+    return forwardRef ? forwardRef(Styled) : Styled;
   };
 }
 
-export { styled, setPragma };
+export { styled, setPragma, setForwardRef };


### PR DESCRIPTION
Fixes #22.

With this, user can setup `setForwardRef` like how they do `setPragma`, i.e.

```
setForwardRef(React.forwardRef)
```

~I'll add tests accordingly if this implementation is ok.~ Added tests

The few lines that I added seem to bring the bundle size to slightly over 1KB though. Any idea on how to bring the size down?
 
```
       1049 B: goober.js.gz
        938 B: goober.js.br
       1056 B: goober.module.js.gz
        944 B: goober.module.js.br
       1102 B: goober.umd.js.gz
        982 B: goober.umd.js.br

 FAIL  ./dist/goober.js: 1.02KB > maxSize 1KB (gzip)
 FAIL  ./dist/goober.module.js: 1.03KB > maxSize 1KB (gzip)
```