### PR TITLE
Remove an now-unnecessary code remnant

### DIFF
--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -6,9 +6,7 @@ import { parse } from './parse';
 /**
  * In-memory cache.
  */
-let cache = {
-    c: 0
-};
+let cache = {};
 
 /**
  * Generates the needed className


### PR DESCRIPTION
This pull request makes a small change to `src/core/hash.js`, removing a piece of code that is a remnant on an older approach that's not used anymore (based on a chat discussion with @cristianbote).