### PR TITLE
Fix typings for nested styled components and empty props

### DIFF
--- a/goober.d.ts
+++ b/goober.d.ts
@@ -5,7 +5,7 @@ export = goober;
 export as namespace goober;
 
 declare namespace goober {
-    function styled<T = { [prop: string]: any }>(tag: string | Tagged<any>): Tagged<T>;
+    function styled<T = {}>(tag: string | StyledVNode<any>): Tagged<T & { children: any }>;
     function setPragma<T>(val: T): void;
     function extractCss(): string;
     function glob(tag: CSSAttribute | TemplateStringsArray | string): void;

--- a/goober.d.ts
+++ b/goober.d.ts
@@ -5,7 +5,7 @@ export = goober;
 export as namespace goober;
 
 declare namespace goober {
-    function styled<T = {}>(tag: string): Tagged<T>;
+    function styled<T = { [prop: string]: any }>(tag: string | Tagged<any>): Tagged<T>;
     function setPragma<T>(val: T): void;
     function extractCss(): string;
     function glob(tag: CSSAttribute | TemplateStringsArray | string): void;

--- a/ts-tests/test-api.tsx
+++ b/ts-tests/test-api.tsx
@@ -26,6 +26,14 @@ const testStyledCss = () => {
         background: black;
     `;
 
+    const EmptyPropsText = styled('p')`
+        color: blue;
+    `;
+
+    const NestedText = styled(EmptyPropsText)`
+        color: red;
+    `;
+
     const TestComp = () => {
         return (
             <div>
@@ -35,6 +43,8 @@ const testStyledCss = () => {
                 <ButtonRaw clicked={false}>click me</ButtonRaw>
                 <button class={buttonStyles({ color: 'red' })}>click me</button>
                 <button class={buttonStylesRaw()}>click me</button>
+                <EmptyPropsText>base text</EmptyPropsText>
+                <NestedText>text</NestedText>
             </div>
         );
     };


### PR DESCRIPTION
This PR fixes two issues:

Currently, TypeScript will incorrectly report `styled(InnerGooberComponent)` as invalid since it expects the type of `tag` to be a string. This will error when nesting components together. We add a Union type to allow nesting components.

As well, related to #80,  TypeScript will complain that the type of the VDom element returned by `styled` is incompatible since it does not have a children prop. From https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32843 it seems like the best way to fix this is to add a children prop to the type. 
