### PR TITLE
Add a Babel plugin for styled.<tagName> syntax (resembling styled-components)

### DIFF
--- a/packages/babel-plugin-transform-goober/README.md
+++ b/packages/babel-plugin-transform-goober/README.md
@@ -1,0 +1,53 @@
+# babel-plugin-transform-goober
+
+A [Babel](https://babeljs.io/) plugin for
+[🥜goober](https://github.com/cristianbote/goober), rewriting `styled.div` syntax to `styled('div')` calls.
+
+## Install
+
+`npm install --save babel-plugin-transform-goober`
+
+## How to use
+
+Edit `.babelrc.json`
+
+```json
+{
+  "presets": [...],
+  "plugins": ["babel-plugin-transform-goober]
+}
+```
+
+And now you can create your components using `styled.*` syntax:
+
+```jsx
+import React from 'react';
+import { styled } from 'goober';
+
+const Button = styled.button`
+    margin: 0;
+    padding: 1rem;
+    font-size: 1rem;
+    background-color: tomato;
+`;
+```
+
+If you want to use some other identifier than `styled` you need to
+tell the plugin about it. Set the configuration option `"name"` to the
+identifier name that want to use. For example, a `.babelrc.json` file like this:
+
+```json
+{
+  "presets": [...],
+  "plugins": [["babel-plugin-transform-goober", { "name" : "goober" }]]
+}
+```
+
+allows you to use goober like this:
+
+```jsx
+import React from 'react';
+import { styled as goober } from 'goober';
+
+const Button = goober.button`...`;
+```

--- a/packages/babel-plugin-transform-goober/__tests__/index.test.js
+++ b/packages/babel-plugin-transform-goober/__tests__/index.test.js
@@ -25,4 +25,10 @@ describe('babel-plugin-transform-goober', () => {
     it('does not rewrite styled.* if "name" is set to something else', () => {
         expect(transform('styled.div;', { name: 'named' })).toEqual('styled.div;');
     });
+    it('requires the root to be an identifier', () => {
+        expect(transform('"styled".div;')).toEqual('"styled".div;');
+    });
+    it('does requires the tag name to be an identifier', () => {
+        expect(transform('styled["div"];')).toEqual('styled["div"];');
+    });
 });

--- a/packages/babel-plugin-transform-goober/__tests__/index.test.js
+++ b/packages/babel-plugin-transform-goober/__tests__/index.test.js
@@ -1,0 +1,28 @@
+const plugin = require('../index.js');
+const { transform: _transform } = require('@babel/core');
+
+function transform(input, options = {}) {
+    return _transform(input, {
+        babelrc: false,
+        configFile: false,
+        plugins: [[plugin, options]]
+    }).code;
+}
+
+describe('babel-plugin-transform-goober', () => {
+    it('works for standalone expressions', () => {
+        expect(transform('styled.div;')).toEqual('styled("div");');
+    });
+    it('works for tagged templates', () => {
+        expect(transform('styled.div``;')).toEqual('styled("div")``;');
+    });
+    it('works for calls', () => {
+        expect(transform('styled.div("hello");')).toEqual('styled("div")("hello");');
+    });
+    it('accepts the option "name"', () => {
+        expect(transform('named.div;', { name: 'named' })).toEqual('named("div");');
+    });
+    it('does not rewrite styled.* if "name" is set to something else', () => {
+        expect(transform('styled.div;', { name: 'named' })).toEqual('styled.div;');
+    });
+});

--- a/packages/babel-plugin-transform-goober/__tests__/index.test.js
+++ b/packages/babel-plugin-transform-goober/__tests__/index.test.js
@@ -28,7 +28,7 @@ describe('babel-plugin-transform-goober', () => {
     it('requires the root to be an identifier', () => {
         expect(transform('"styled".div;')).toEqual('"styled".div;');
     });
-    it('does requires the tag name to be an identifier', () => {
-        expect(transform('styled["div"];')).toEqual('styled["div"];');
+    it('does not require the tag name to be an identifier', () => {
+        expect(transform('styled["div"];')).toEqual('styled("div");');
     });
 });

--- a/packages/babel-plugin-transform-goober/index.js
+++ b/packages/babel-plugin-transform-goober/index.js
@@ -1,0 +1,23 @@
+module.exports = function({ types: t }, options = {}) {
+    const name = options.name || 'styled';
+
+    return {
+        name: 'transform-goober',
+        visitor: {
+            MemberExpression: {
+                exit(path) {
+                    const node = path.node;
+                    if (!t.isIdentifier(node.object) || node.object.name !== name) {
+                        return;
+                    }
+                    if (!t.isIdentifier(node.property)) {
+                        return;
+                    }
+                    path.replaceWith(
+                        t.callExpression(node.object, [t.stringLiteral(node.property.name)])
+                    );
+                }
+            }
+        }
+    };
+};

--- a/packages/babel-plugin-transform-goober/index.js
+++ b/packages/babel-plugin-transform-goober/index.js
@@ -10,12 +10,11 @@ module.exports = function({ types: t }, options = {}) {
                     if (!t.isIdentifier(node.object) || node.object.name !== name) {
                         return;
                     }
-                    if (!t.isIdentifier(node.property)) {
-                        return;
+                    let property = node.property;
+                    if (t.isIdentifier(property)) {
+                        property = t.stringLiteral(property.name);
                     }
-                    path.replaceWith(
-                        t.callExpression(node.object, [t.stringLiteral(node.property.name)])
-                    );
+                    path.replaceWith(t.callExpression(node.object, [property]));
                 }
             }
         }

--- a/packages/babel-plugin-transform-goober/package.json
+++ b/packages/babel-plugin-transform-goober/package.json
@@ -16,8 +16,5 @@
     "scripts": {},
     "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-    },
-    "devDependencies": {
-        "@babel/core": "^7.5.5"
     }
 }

--- a/packages/babel-plugin-transform-goober/package.json
+++ b/packages/babel-plugin-transform-goober/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "babel-plugin-transform-goober",
+    "version": "1.0.0",
+    "description": "A Babel plugin for goober, rewriting styled.div syntax to styled('div') calls",
+    "main": "index.js",
+    "license": "ISC",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/cristianbote/goober.git",
+        "directory": "packages/babel-plugin-transform-goober"
+    },
+    "author": "Joachim Viide <jviide@iki.fi>",
+    "keywords": [
+        "babel-plugin"
+    ],
+    "scripts": {},
+    "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.5.5"
+    }
+}


### PR DESCRIPTION
This pull request is based on issue #69 and chat discussions with @cristianbote and @JoviDeCroock. It adds a Babel plugin called babel-plugin-transform-goober under `/packages/babel-plugin-transform-goober`. The plugin is for rewriting [styled-components](https://styled-components.com/)-like `styled.<tagName>` syntax to `styled("<tagName>")` calls.

The plugin rewrites all expressions in the form `styled.*` to `styled("*")`. Therefore things like calls and tagged expressions also work. For example the following file:

```js
style.div;
style.div`...`;
style.div("...");
```

gets rewritten to:

```js
style("div";
style("div")`...`;
style("div")("...");
```

The plugin is enabled by adding it to the Babel configuration:
```json
{
  "presets": [...],
  "plugins": ["babel-plugin-transform-goober]
}
```

By default the plugin assumes that the root identifier is `styled`. If there is a need to use some other name then the plugin can be configured by setting the `"name"` option. For example the configuration:

```json
{
  "presets": [...],
  "plugins": [["babel-plugin-transform-goober", { "name" : "goober" }]]
}
```

allows you to write code like this:

```jsx
import React from 'react';
import { styled as goober } from 'goober';

const Button = goober.button`...`;
```

Related tests are included.