### PR TITLE
Modify hashing (use uint32 results, add an initial value & new multiplier)

### DIFF
--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -31,6 +31,6 @@ describe('integrations', () => {
             target
         );
 
-        expect(extractCss()).toEqual(' .go2155{color:red;}');
+        expect(extractCss()).toEqual(' .go3917434385{color:red;}');
     });
 });

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -31,6 +31,6 @@ describe('integrations', () => {
             target
         );
 
-        expect(extractCss()).toEqual(' .go3917434385{color:red;}');
+        expect(extractCss()).toEqual(' .go3707426746{color:red;}');
     });
 });

--- a/src/core/__tests__/to-hash.test.js
+++ b/src/core/__tests__/to-hash.test.js
@@ -4,8 +4,8 @@ describe('to-hash', () => {
     it('regression', () => {
         const res = toHash('goober');
 
-        expect(res).toEqual('.go3054717608');
-        expect(toHash('goober')).toEqual('.go3054717608');
+        expect(res).toEqual('.go1990315141');
+        expect(toHash('goober')).toEqual('.go1990315141');
     });
 
     it('collision', () => {

--- a/src/core/__tests__/to-hash.test.js
+++ b/src/core/__tests__/to-hash.test.js
@@ -4,8 +4,8 @@ describe('to-hash', () => {
     it('regression', () => {
         const res = toHash('goober');
 
-        expect(res).toEqual('.go650');
-        expect(toHash('goober')).toEqual('.go650');
+        expect(res).toEqual('.go3054717608');
+        expect(toHash('goober')).toEqual('.go3054717608');
     });
 
     it('collision', () => {

--- a/src/core/to-hash.js
+++ b/src/core/to-hash.js
@@ -3,4 +3,4 @@
  * @param {String} str
  */
 export const toHash = str =>
-    '.go' + str.split('').reduce((out, i) => (31 * out + i.charCodeAt(0)) | 0, 0);
+    '.go' + str.split('').reduce((out, i) => (31 * out + i.charCodeAt(0)) >>> 0, 0);

--- a/src/core/to-hash.js
+++ b/src/core/to-hash.js
@@ -1,6 +1,10 @@
 /**
- * Transforms the input into a className
+ * Transforms the input into a className.
+ * The multiplication constant 101 is selected to be a prime,
+ * as is the initial value of 11.
+ * The intermediate and final results are truncated into 32-bit
+ * unsigned integers.
  * @param {String} str
  */
 export const toHash = str =>
-    '.go' + str.split('').reduce((out, i) => (31 * out + i.charCodeAt(0)) >>> 0, 0);
+    '.go' + str.split('').reduce((out, i) => (101 * out + i.charCodeAt(0)) >>> 0, 11);


### PR DESCRIPTION
This pull request modifies `to-hash.js` to return _unsigned_ 32-bit integer values. The multiplication constant is now 101 and the initial value for hash a non-zero (11).

The constants are chosen pretty arbitrarily by what seems to give good results, as long as the multiplier is a prime (or at least a prime relative to 2^n).

The tests are modified accordingly.