### PR TITLE
Update TypeScript definitions and css API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ setPragma(React.createElement);
 
 ### `css(taggedTemplate)`
 
--   `@returns {Function}` Returns the tag template function.
+-   `@returns {String}` Returns the className.
 
-Same as `styled` but without the tagName and vNode generation. Calling the function created by `css` will result in a className.
+To create a className, you need to call `css` with your style rules in a tagged template.
 
 ```js
 import { css } from "goober";
@@ -210,23 +210,40 @@ const BtnClassName = css`
 
 // vanilla JS
 const btn = document.querySelector("#btn");
-// BtnClassName() -> 'g016232'
-btn.classList.add(BtnClassName());
+// BtnClassName === 'g016232'
+btn.classList.add(BtnClassName);
 
 // JSX
-// BtnClassName() -> 'g016232'
-const App => <button className={BtnClassName()}>click</button>
+// BtnClassName === 'g016232'
+const App => <button className={BtnClassName}>click</button>
 ```
 
 #### Different ways of customizing `css`
 
-##### Tagged templates functions
+##### Passing props to `css` tagged templates
 
 ```js
 import { css } from 'goober';
 
-const BtnClassName = css`
-    border-radius: ${props => props.size}px;
+// JSX
+const CustomButton = props => (
+    <button
+        className={css`
+            border-radius: ${props.size}px;
+        `}
+    >
+        click
+    </button>
+);
+```
+
+We also can declare the styles at the top of the file by wrapping `css` into a function that we call to get the className.
+
+```js
+import { css } from 'goober';
+
+const BtnClassName = props => css`
+    border-radius: ${props.size}px;
 `;
 
 // vanilla JS
@@ -237,20 +254,6 @@ btn.classList.add(BtnClassName({ size: 20 }));
 // JSX
 // BtnClassName({size:20}) -> g016360
 const App = () => <button className={BtnClassName({ size: 20 })}>click</button>;
-```
-
-**💡NOTE**
-
-> If you provide props as an object within `css`, make sure to provide empty object as a default parameter, otherwise your app will throw error if you won't provide an object argument.
-
-```js
-const BtnClassName = css`
-    border-radius: ${(props = {}) => props.size}px;
-`;
-
-// All Good
-BtnClassName();
-BtnClassName({ size: 4 });
 ```
 
 ### `targets`

--- a/goober.d.ts
+++ b/goober.d.ts
@@ -8,18 +8,22 @@ declare namespace goober {
     function styled<T = {}>(tag: string | StyledVNode<any>): Tagged<T & { children: any }>;
     function setPragma<T>(val: T): void;
     function extractCss(): string;
-    function glob(tag: CSSAttribute | TemplateStringsArray | string): void;
-    function css<T extends unknown = void>(
-        tag: TemplateStringsArray,
-        props?: (props: T) => string
-    ): CssFactory<T>;
+    function glob(
+        tag: CSSAttribute | TemplateStringsArray | string,
+        ...props: Array<string | number>
+    ): void;
+    function css(
+        tag: CSSAttribute | TemplateStringsArray | string,
+        ...props: Array<string | number>
+    ): string;
     type StyledVNode<T> = (props: T, ...args: any[]) => any;
     type Tagged<T> = (
-        tag: CSSAttribute | TemplateStringsArray,
-        ...props: Array<(props: T) => CSSAttribute | string | number | undefined>
+        tag: CSSAttribute | TemplateStringsArray | string | ((props: T) => CSSAttribute | string),
+        ...props: Array<
+            string | number | ((props: T) => CSSAttribute | string | number | undefined)
+        >
     ) => StyledVNode<T>;
     interface CSSAttribute extends CSSProperties {
         [key: string]: CSSAttribute | string | number | undefined;
     }
-    type CssFactory<T> = (props: T) => string;
 }

--- a/ts-tests/test-api.tsx
+++ b/ts-tests/test-api.tsx
@@ -10,8 +10,8 @@ const testStyledCss = () => {
         color?: string;
     }
 
-    const buttonStyles = css<Pick<ButtonProps, 'color'>>`
-        background: ${props => props.color || 'black'};
+    const buttonStyles = ({ color }: Pick<ButtonProps, 'color'>) => css`
+        background: ${color || 'black'};
     `;
 
     const buttonStylesRaw = css`
@@ -47,7 +47,7 @@ const testStyledCss = () => {
                 </Button>
                 <ButtonRaw clicked={false}>click me</ButtonRaw>
                 <button class={buttonStyles({ color: 'red' })}>click me</button>
-                <button class={buttonStylesRaw()}>click me</button>
+                <button class={buttonStylesRaw}>click me</button>
                 <EmptyPropsText>base text</EmptyPropsText>
                 <NestedText>text</NestedText>
             </div>


### PR DESCRIPTION
On this change I updated the docs to clarify how the css(taggedTemplate) examples (#89).

I also updated the TypeScript definitions to fix some of the issues we were facing.