### PR TITLE
(bug) Allow glob to be parsed and appended as needed (#106)

### DIFF
--- a/src/core/__tests__/hash.test.js
+++ b/src/core/__tests__/hash.test.js
@@ -61,12 +61,12 @@ describe('hash', () => {
     it('regression: global', () => {
         const res = hash('global', 'target', true);
 
-        expect(toHash).not.toBeCalled();
-        expect(astish).toBeCalledWith('global');
-        expect(parse).toBeCalledWith('astish()', '');
+        expect(toHash).toBeCalledWith('"global"');
+        expect(astish).not.toBeCalled();
+        expect(parse).not.toBeCalled();
         expect(update).toBeCalledWith('parse()', 'target', undefined);
 
-        expect(res).toEqual('');
+        expect(res).toEqual('toHash()');
     });
 
     it('regression: object', () => {

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -19,12 +19,12 @@ let cache = {};
 export const hash = (compiled, sheet, g, append) => {
     // generate hash
     const compString = JSON.stringify(compiled);
-    const className = cache[compString] || (cache[compString] = g ? '' : toHash(compString));
+    const className = cache[compString] || (cache[compString] = toHash(compString));
 
     // Parse the compiled
     const parsed =
         cache[className] ||
-        (cache[className] = parse(compiled[0] ? astish(compiled) : compiled, className));
+        (cache[className] = parse(compiled[0] ? astish(compiled) : compiled, g ? '' : className));
 
     // add or update
     update(parsed, sheet, append);


### PR DESCRIPTION
`glob` should be able to interpolate dynamic values passed along.