### PR TITLE
(fix) Allow zero values (#108)

### DIFF
--- a/src/core/__tests__/compile.test.js
+++ b/src/core/__tests__/compile.test.js
@@ -24,6 +24,6 @@ describe('compile', () => {
 
     it('value interpolations', () => {
         // This interpolations are testing the ability to interpolate thruty and falsy values
-        expect(template`prop: 1; ${() => 1},${() => undefined},${2}`({})).toEqual('prop: 1; 1,,2');
+        expect(template`prop: 1; ${() => 0},${() => undefined},${2}`({})).toEqual('prop: 1; 0,,2');
     });
 });

--- a/src/core/compile.js
+++ b/src/core/compile.js
@@ -28,6 +28,6 @@ export const compile = (str, defs, data) => {
                 ? ''
                 : res;
         }
-        return out + next + (tail || '');
+        return out + next + (tail == null ? '' : tail);
     }, '');
 };


### PR DESCRIPTION
Allow zero values inside tagged templates.

Adds `+5B` 😞 