### PR TITLE
(chore) Revamp the fwd ref and add nested test

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,10 @@
   "typings": "./goober.d.ts",
   "filesize": {
     "./dist/goober.module.js": {
-      "gzip": "1080B"
+      "gzip": "1090B"
     },
     "./dist/goober.js": {
-      "gzip": "1080B"
+      "gzip": "1090B"
     }
   },
   "lint-staged": {

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -12,9 +12,9 @@ describe('integrations', () => {
 
         const target = document.createElement('div');
 
-        const Span = forwardRef(styled('span')`
+        const Span = styled('span', forwardRef)`
             color: red;
-        `);
+        `;
 
         const BoxWithColor = styled('div')`
             color: ${(props) => props.color};
@@ -42,7 +42,7 @@ describe('integrations', () => {
             <ThemeContext.Provider value={{ color: 'blue' }}>
                 <div>
                     <Span ref={refSpy} />
-                    <Span as="div" /> */}
+                    <Span as="div" />
                     <BoxWithColor color={'red'} />
                     <Span as={BoxWithColor} color={'red'} />
                     <BoxWithColorFn color={'red'} />

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -8,13 +8,13 @@ describe('integrations', () => {
         const ThemeContext = createContext();
         const useTheme = () => useContext(ThemeContext);
 
-        setup(h, null, forwardRef, useTheme);
+        setup(h, null, useTheme);
 
         const target = document.createElement('div');
 
-        const Span = styled('span')`
+        const Span = forwardRef(styled('span')`
             color: red;
-        `;
+        `);
 
         const BoxWithColor = styled('div')`
             color: ${(props) => props.color};
@@ -42,7 +42,9 @@ describe('integrations', () => {
             <ThemeContext.Provider value={{ color: 'blue' }}>
                 <div>
                     <Span ref={refSpy} />
+                    <Span as="div" /> */}
                     <BoxWithColor color={'red'} />
+                    <Span as={BoxWithColor} color={'red'} />
                     <BoxWithColorFn color={'red'} />
                     <BoxWithThemeColor />
                     <BoxWithThemeColorFn />
@@ -56,6 +58,7 @@ describe('integrations', () => {
         expect(extractCss()).toMatchInlineSnapshot(
             `" .go3865451590{color:red;}.go1925576363{color:blue;}.go3206651468{color:green;}.go4276997079{color:orange;}"`
         );
+
         expect(refSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 tagName: 'SPAN'

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -42,9 +42,7 @@ describe('integrations', () => {
             <ThemeContext.Provider value={{ color: 'blue' }}>
                 <div>
                     <Span ref={refSpy} />
-                    <Span as="div" />
                     <BoxWithColor color={'red'} />
-                    <Span as={BoxWithColor} color={'red'} />
                     <BoxWithColorFn color={'red'} />
                     <BoxWithThemeColor />
                     <BoxWithThemeColorFn />

--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -79,18 +79,20 @@ describe('styled', () => {
             .fn()
             .mockImplementation((Styled) => (props) => Styled(props, 'ref'));
         const p = { bar: 1 };
-        setup(_h, null, forwardRef);
+        setup(_h, null);
 
         expect(
-            styled('tag')`
-                foo: 1;
-            `(p)
+            forwardRef(
+                styled('tag')`
+                    foo: 1;
+                `
+            )(p)
         ).toEqual('h()');
+
         expect(_h).toBeCalledWith(
             'tag',
             Object.assign({}, p, { className: 'css()', ref: 'ref', theme: undefined })
         );
-        expect(forwardRef).toHaveBeenCalled();
     });
 
     it('setup useTheme', () => {
@@ -104,7 +106,7 @@ describe('styled', () => {
         const _h = jest.fn().mockReturnValue('h()');
         const useTheme = jest.fn().mockReturnValue('theme');
         const p = { bar: 1 };
-        setup(_h, null, null, useTheme);
+        setup(_h, null, useTheme);
 
         const styleFn = jest.fn().mockReturnValue({ color: 'red' });
         expect(styled('tag')(styleFn)(p)).toEqual('h()');
@@ -133,7 +135,7 @@ describe('styled', () => {
         const _h = jest.fn().mockReturnValue('h()');
         const useTheme = jest.fn().mockReturnValue('theme');
         const p = { theme: 'override' };
-        setup(_h, null, null, useTheme);
+        setup(_h, null, useTheme);
 
         const styleFn = jest.fn().mockReturnValue({ color: 'red' });
         expect(styled('tag')(styleFn)(p)).toEqual('h()');

--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -82,11 +82,9 @@ describe('styled', () => {
         setup(_h, null);
 
         expect(
-            forwardRef(
-                styled('tag')`
-                    foo: 1;
-                `
-            )(p)
+            styled('tag', forwardRef)`
+                foo: 1;
+            `(p)
         ).toEqual('h()');
 
         expect(_h).toBeCalledWith(

--- a/src/core/__tests__/parse.test.js
+++ b/src/core/__tests__/parse.test.js
@@ -169,7 +169,7 @@ describe('parse', () => {
     });
 
     // Not... supported
-    xit('@supports', () => {
+    it.skip('@supports', () => {
         expect(
             parse(
                 {
@@ -182,5 +182,27 @@ describe('parse', () => {
                 'hash'
             )
         ).toEqual(['@supports (some: 1px){@media (s: 1){hush{display:flex;}}}']);
+    });
+
+    it.skip('nested with multiple selector', () => {
+        const out = parse(
+            {
+                display: 'value',
+                '&:hover,&:focus': {
+                    border: '0',
+                    span: {
+                        index: 'unset'
+                    }
+                }
+            },
+            'hush'
+        );
+        expect(out).toEqual(
+            [
+                'hush{display:value;}',
+                'hush:hover,hush:focus{border:0;}',
+                'hush:hover span,hush:focus span{index:unset;}'
+            ].join('')
+        );
     });
 });

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -57,10 +57,7 @@ export const parse = (obj, paren, wrapper) => {
         const rule = paren + '{' + current + '}';
 
         // With wrapper
-        if (wrapper) {
-            // if (wrapper[0] == '@' && !paren) rule = paren + current;
-            return blocks + wrapper + '{' + rule + '}';
-        }
+        if (wrapper) return blocks + wrapper + '{' + rule + '}';
 
         // Else just push the rule
         return outer + rule + blocks;

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -57,7 +57,10 @@ export const parse = (obj, paren, wrapper) => {
         const rule = paren + '{' + current + '}';
 
         // With wrapper
-        if (wrapper) return blocks + wrapper + '{' + rule + '}';
+        if (wrapper) {
+            // if (wrapper[0] == '@' && !paren) rule = paren + current;
+            return blocks + wrapper + '{' + rule + '}';
+        }
 
         // Else just push the rule
         return outer + rule + blocks;

--- a/src/styled.js
+++ b/src/styled.js
@@ -12,19 +12,20 @@ function setup(pragma, prefix, theme) {
 }
 
 /**
- * Styled function
- * @param {String} tag
+ * styled function
+ * @param {string} tag
+ * @param {function} forwardRef
  */
-function styled(tag) {
+function styled(tag, forwardRef) {
     const _ctx = this || {};
 
     return function wrapper() {
         const _args = arguments;
 
-        return function Styled(props, ref) {
+        function Styled(props, ref) {
             // Grab a shallow copy of the props
             // _ctx.p: is the props sent to the context
-            const _props = (_ctx.p = Object.assign({ theme: useTheme && useTheme(), ref }, props));
+            const _props = (_ctx.p = Object.assign({ theme: useTheme && useTheme() }, props));
             const _previousClassName = _props.className;
 
             // Set a flag if the current components had a previous className
@@ -35,8 +36,15 @@ function styled(tag) {
             _props.className =
                 css.apply(_ctx, _args) + (_previousClassName ? ' ' + _previousClassName : '');
 
+            // If the forwardRef fun is defined we have the ref
+            if (forwardRef) {
+                _props.ref = ref;
+            }
+
             return h(tag, _props);
-        };
+        }
+
+        return forwardRef ? forwardRef(Styled) : Styled;
     };
 }
 

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,16 +1,15 @@
 import { css } from './css';
 import { parse } from './core/parse';
 
-let h, forwardRef, useTheme;
-const setup = (pragma, prefix, fwd, theme) => {
+let h, useTheme;
+function setup(pragma, prefix, theme) {
     // This one needs to stay in here, so we won't have cyclic dependencies
     parse.p = prefix;
 
     // These are scope to this context
     h = pragma;
-    forwardRef = fwd;
     useTheme = theme;
-};
+}
 
 /**
  * Styled function
@@ -22,10 +21,10 @@ function styled(tag) {
     return function wrapper() {
         const _args = arguments;
 
-        function Styled(props, ref) {
+        return function Styled(props, ref) {
             // Grab a shallow copy of the props
             // _ctx.p: is the props sent to the context
-            const _props = (_ctx.p = Object.assign({ theme: useTheme && useTheme() }, props));
+            const _props = (_ctx.p = Object.assign({ theme: useTheme && useTheme(), ref }, props));
             const _previousClassName = _props.className;
 
             // Set a flag if the current components had a previous className
@@ -36,13 +35,8 @@ function styled(tag) {
             _props.className =
                 css.apply(_ctx, _args) + (_previousClassName ? ' ' + _previousClassName : '');
 
-            // Add the passed ref function to props
-            _props.ref = ref;
-
             return h(tag, _props);
-        }
-
-        return forwardRef ? forwardRef(Styled) : Styled;
+        };
     };
 }
 


### PR DESCRIPTION
Adds the test for #47 and rewires the forward ref.

@lucat1 pointed out that the current forward ref implementation does not properly work if one tries to import a component before calling `setup`. Which makes total sense. So, this PR address it like this:
* ~~We have support for `styled` to be directly passed to `React.forwardRef`~~ We still have that support but `forwardRef` should be passed as second argument to `styled`.
* `setup` no longer needs the forward ref function.

This boils down to this:
```js
const Foo = styled('div', React.forwardRef)`
    background: tomato;
`;
```