### PR TITLE
Support node 13

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -5,6 +5,10 @@ on: [pull_request]
 jobs:
     build:
         runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            # Change the condition for ESM Dist Test below when changing this.
+            node-version: [10.x, 12.x, 14.x]
 
         steps:
             - uses: actions/checkout@v2-beta
@@ -14,3 +18,6 @@ jobs:
               run: npm install
             - name: Run tests
               run: npm run test
+            - if: matrix.node-version == '14.x'
+              name: ESM Dist Test
+              run: npm run test:dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 debug
 sandbox
 coverage
+goober.tgz
+tests/fixtures/esm/package-lock.json

--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+
+const subRepositories = ['goober-autoprefixer'];
+
+const copyGoober = () => {
+    // Copy .module.js --> .mjs for Node 13 compat.
+    fs.writeFileSync(
+        `${process.cwd()}/dist/goober.mjs`,
+        fs.readFileSync(`${process.cwd()}/dist/goober.module.js`)
+    );
+};
+
+const copy = (name) => {
+    // Copy .module.js --> .mjs for Node 13 compat.
+    fs.writeFileSync(
+        `${process.cwd()}/packages/${name}/dist/${name}.mjs`,
+        fs.readFileSync(`${process.cwd()}/packages/${name}/dist/${name}.module.js`)
+    );
+};
+
+copyGoober();
+subRepositories.forEach(copy);

--- a/package.json
+++ b/package.json
@@ -16,11 +16,21 @@
     "typings.json",
     "goober.d.ts"
   ],
+  "exports": {
+    ".": {
+      "browser": "./dist/goober.module.js",
+      "umd": "./dist/goober.umd.js",
+      "import": "./dist/goober.mjs",
+      "require": "./dist/goober.js"
+    },
+    "./": "./"
+  },
   "scripts": {
     "test": "npm run test-ts && npm run test-unit -- --ci --coverage && npm run build && npm run test-perf",
     "test-perf": "NODE_ENV=production node benchmarks/perf.js",
     "test-unit": "jest --setupFiles ./tests/setup.js",
     "test-ts": "tsc -p ts-tests",
+    "test-dist": "npm pack && mv goober*.tgz tests/fixtures/esm/goober.tgz && cd tests/fixtures/esm && npm install && node index.js",
     "clean": "rimraf dist",
     "size-check": "filesize",
     "build": "npm run build:core && npm run build:prefixer",
@@ -29,6 +39,7 @@
     "build:lib": "microbundle --entry src/index.js --name goober --no-sourcemap",
     "build:dist": "npm run build:lib -- --output dist",
     "build:debug": "npm run build:lib -- --output debug --no-compress",
+    "postbuild": "node ./config/node-13-exports.js",
     "dev": "npm run clean && microbundle watch --entry src/index.js --output dist --name goober",
     "deploy": "npm run build && npm publish",
     "format": "prettier \"**/*.{js,ts,tsx,md}\" --write"

--- a/packages/goober-autoprefixer/package.json
+++ b/packages/goober-autoprefixer/package.json
@@ -6,5 +6,14 @@
   "umd:main": "./dist/goober-autoprefixer.umd.js",
   "source": "./src/index.js",
   "unpkg": "./dist/goober-autoprefixer.umd.js",
-  "types": "./autoprefixer.d.ts"
+  "types": "./autoprefixer.d.ts",
+  "exports": {
+    ".": {
+      "browser": "./dist/goober-autoprefixer.module.js",
+      "umd": "./dist/goober-autoprefixer.umd.js",
+      "import": "./dist/goober-autoprefixer.mjs",
+      "require": "./dist/goober-autoprefixer.js"
+    },
+    "./": "./"
+  }
 }

--- a/tests/fixtures/esm/index.js
+++ b/tests/fixtures/esm/index.js
@@ -1,0 +1,9 @@
+import assert from 'assert';
+import * as goober from 'goober';
+
+assert(typeof goober.css === 'function', 'import { css } from "goober"');
+assert(typeof goober.styled === 'function', 'import { styled } from "goober"');
+assert(typeof goober.setup === 'function', 'import { setup } from "goober"');
+assert(typeof goober.glob === 'function', 'import { glob } from "goober"');
+
+console.log('✅ Dist Tests Passed');

--- a/tests/fixtures/esm/package.json
+++ b/tests/fixtures/esm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "goober_dist_test",
+  "type": "module",
+  "private": true,
+  "description": "A package to test importing goober as ES modules in Node",
+  "dependencies": {
+    "goober": "file:goober.tgz"
+  }
+}


### PR DESCRIPTION
Hi there! First of all, thanks for this wonderful library. I'm really enjoying using it.

I've been trying to use it with Node 13's new ESM support, and saw that that was still missing, hence this PR. I've basically copied exactly what Preact is doing: https://github.com/preactjs/preact/pull/2451.

Of the sub-packages, only `goober-autoprefixer` is currently being built, as it appears the other ones don't need to be built at all, as far as I can see?

I've added a basic test, taken directly from HTM: https://github.com/developit/htm/pull/164

The filesize test is currently failing, which is why this might fail in CI.
