### PR TITLE
(chore) Add goober-autoprefixer to gatsby plugin

### DIFF
--- a/packages/gatsby-plugin-goober/gatsby-browser.js
+++ b/packages/gatsby-plugin-goober/gatsby-browser.js
@@ -1,3 +1,5 @@
 import React from 'react';
 import { setup } from 'goober';
-setup(React.createElement);
+import { prefix } from 'goober-autoprefixer';
+
+setup(React.createElement, prefix);

--- a/packages/gatsby-plugin-goober/gatsby-ssr.js
+++ b/packages/gatsby-plugin-goober/gatsby-ssr.js
@@ -1,8 +1,9 @@
 const React = require('react');
 const goober = require('goober');
+const autoprefixer = require('goober-autoprefixer');
 
 // Set the pragma for `goober` to know which to use
-goober.setup(React.createElement);
+goober.setup(React.createElement, autoprefixer.prefix);
 
 // Define a cache entry
 const cache = new Map();

--- a/packages/gatsby-plugin-goober/package.json
+++ b/packages/gatsby-plugin-goober/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gatsby-plugin-goober",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Gatsby plugin to add support for goober",
     "main": "index.js",
     "scripts": {},

--- a/packages/gatsby-plugin-goober/package.json
+++ b/packages/gatsby-plugin-goober/package.json
@@ -24,6 +24,7 @@
     "devDependencies": {},
     "peerDependencies": {
         "goober": "^2.0.0",
+        "goober-autoprefixer": "^1.0.0",
         "gatsby": "^2.10.0"
     },
     "repository": {


### PR DESCRIPTION
Adds `goober-autoprefixer` to `gatsby-plugin-goober`