### PR TITLE
Enhance babel plugin for nicer developer UX

### DIFF
--- a/packages/babel-plugin-transform-goober/README.md
+++ b/packages/babel-plugin-transform-goober/README.md
@@ -14,7 +14,7 @@ Edit `.babelrc.json`
 ```json
 {
   "presets": [...],
-  "plugins": ["babel-plugin-transform-goober]
+  "plugins": ["babel-plugin-transform-goober"]
 }
 ```
 
@@ -50,4 +50,35 @@ import React from 'react';
 import { styled as goober } from 'goober';
 
 const Button = goober.button`...`;
+```
+
+## Better Debugging Experience
+
+Setting the `displayName` option to `true`, will add richer component names and additional CSS classes to the component. This makes it easier to find your components in the devtools or in your HTML.
+
+```json
+{
+  "presets": [...],
+  "plugins": [["babel-plugin-transform-goober", { "displayName" : true }]]
+}
+```
+
+Example output:
+
+```js
+// with displayName: false
+<button className="go1231232"></button>
+// with displayName: true
+<button className="Sidebar__Button-go-1 go1231232"></button>
+```
+
+## Dead Code Elimination
+
+Minifiers have a hard time proving that a `styled()` call has no side-effects and therefore won't remove them. By default this plugin will automatically insert `#__PURE__` annotations to mark these functions as pure. You can opt out of this feature at the cost of bigger bundles by passing `pure: false`.
+
+```json
+{
+  "presets": [...],
+  "plugins": [["babel-plugin-transform-goober", { "pure" : false }]]
+}
 ```

--- a/packages/babel-plugin-transform-goober/__tests__/__fixtures__/123.txt
+++ b/packages/babel-plugin-transform-goober/__tests__/__fixtures__/123.txt
@@ -1,0 +1,1 @@
+const Foo = styled("div")``;

--- a/packages/babel-plugin-transform-goober/__tests__/__fixtures__/multiple.txt
+++ b/packages/babel-plugin-transform-goober/__tests__/__fixtures__/multiple.txt
@@ -1,0 +1,3 @@
+const Foo = styled("div")``;
+const Bar = styled("div")``;
+const Baz = styled("div")``;

--- a/packages/babel-plugin-transform-goober/__tests__/__fixtures__/space name.txt
+++ b/packages/babel-plugin-transform-goober/__tests__/__fixtures__/space name.txt
@@ -1,0 +1,1 @@
+const Foo = styled("div")``;

--- a/packages/babel-plugin-transform-goober/__tests__/index.test.js
+++ b/packages/babel-plugin-transform-goober/__tests__/index.test.js
@@ -51,14 +51,14 @@ describe('displayName', () => {
     it('works for const declarations', () => {
         expect(transform('const Foo = styled("div")``', { displayName: true })).toEqual(
             'const Foo = styled("div")``;\n' +
-                'Foo.displayName = "styled(Foo)";\n' +
+                'Foo.displayName = "Foo";\n' +
                 'Foo.className = "Unknown__Foo-go-1";'
         );
     });
     it('works for let declarations', () => {
         expect(transform('let Foo = styled("div")``', { displayName: true })).toEqual(
             'let Foo = styled("div")``;\n' +
-                'Foo.displayName = "styled(Foo)";\n' +
+                'Foo.displayName = "Foo";\n' +
                 'Foo.className = "Unknown__Foo-go-1";'
         );
     });
@@ -73,25 +73,25 @@ describe('displayName', () => {
     it('converts filename into valid css class', () => {
         expect(transformFile('space name', { displayName: true })).toEqual(
             'const Foo = styled("div")``;\n' +
-                'Foo.displayName = "styled(Foo)";\n' +
+                'Foo.displayName = "Foo";\n' +
                 'Foo.className = "space-name__Foo-go-1";'
         );
         expect(transformFile('123', { displayName: true })).toEqual(
             'const Foo = styled("div")``;\n' +
-                'Foo.displayName = "styled(Foo)";\n' +
+                'Foo.displayName = "Foo";\n' +
                 'Foo.className = "-123__Foo-go-1";'
         );
     });
     it('appends component index to debug css class', () => {
         expect(transformFile('multiple', { displayName: true })).toEqual(
             'const Foo = styled("div")``;\n' +
-                'Foo.displayName = "styled(Foo)";\n' +
+                'Foo.displayName = "Foo";\n' +
                 'Foo.className = "multiple__Foo-go-1";\n' +
                 'const Bar = styled("div")``;\n' +
-                'Bar.displayName = "styled(Bar)";\n' +
+                'Bar.displayName = "Bar";\n' +
                 'Bar.className = "multiple__Bar-go-2";\n' +
                 'const Baz = styled("div")``;\n' +
-                'Baz.displayName = "styled(Baz)";\n' +
+                'Baz.displayName = "Baz";\n' +
                 'Baz.className = "multiple__Baz-go-3";'
         );
     });

--- a/packages/babel-plugin-transform-goober/__tests__/index.test.js
+++ b/packages/babel-plugin-transform-goober/__tests__/index.test.js
@@ -1,5 +1,6 @@
 const plugin = require('../index.js');
 const { transform: _transform } = require('@babel/core');
+const { isGetAccessor } = require('typescript');
 
 function transform(input, options = {}) {
     return _transform(input, {
@@ -54,5 +55,28 @@ describe('displayName', () => {
     });
     it('skip transform if not in dev mode', () => {
         expect(transform('const Foo = foo("div")``')).toEqual('const Foo = foo("div")``;');
+    });
+});
+
+describe('annotate #__PURE__ calls', () => {
+    it('prepend comment for calls', () => {
+        expect(transform('const Foo = styled("div")``', { pure: true })).toEqual(
+            'const Foo = /*#__PURE__*/styled("div")``;'
+        );
+    });
+    it('prepend comment for expressions', () => {
+        expect(transform('const Foo = styled.div``', { pure: true })).toEqual(
+            'const Foo = /*#__PURE__*/styled("div")``;'
+        );
+    });
+    it('prepend comment for dynamic properties', () => {
+        expect(transform('const Foo = styled["div"]``', { pure: true })).toEqual(
+            'const Foo = /*#__PURE__*/styled("div")``;'
+        );
+    });
+    it('prepend comment for css calls', () => {
+        expect(transform('const Foo = css``', { pure: true })).toEqual(
+            'const Foo = /*#__PURE__*/css``;'
+        );
     });
 });

--- a/packages/babel-plugin-transform-goober/__tests__/index.test.js
+++ b/packages/babel-plugin-transform-goober/__tests__/index.test.js
@@ -39,17 +39,17 @@ describe('babel-plugin-transform-goober', () => {
 
 describe('displayName', () => {
     it('works for const declarations', () => {
-        expect(transform('const Foo = styled("div")``', { dev: true })).toEqual(
+        expect(transform('const Foo = styled("div")``', { displayName: true })).toEqual(
             'const Foo = styled("div")``;\nFoo.displayName = "styled(Foo)";'
         );
     });
     it('works for let declarations', () => {
-        expect(transform('let Foo = styled("div")``', { dev: true })).toEqual(
+        expect(transform('let Foo = styled("div")``', { displayName: true })).toEqual(
             'let Foo = styled("div")``;\nFoo.displayName = "styled(Foo)";'
         );
     });
     it('only works for styled expressions', () => {
-        expect(transform('const Foo = foo("div")``', { dev: true })).toEqual(
+        expect(transform('const Foo = foo("div")``', { displayName: true })).toEqual(
             'const Foo = foo("div")``;'
         );
     });

--- a/packages/babel-plugin-transform-goober/__tests__/index.test.js
+++ b/packages/babel-plugin-transform-goober/__tests__/index.test.js
@@ -35,3 +35,24 @@ describe('babel-plugin-transform-goober', () => {
         expect(transform('styled["div"];')).toEqual('styled("div");');
     });
 });
+
+describe('displayName', () => {
+    it('works for const declarations', () => {
+        expect(transform('const Foo = styled("div")``', { dev: true })).toEqual(
+            'const Foo = styled("div")``;\nFoo.displayName = "styled(Foo)";'
+        );
+    });
+    it('works for let declarations', () => {
+        expect(transform('let Foo = styled("div")``', { dev: true })).toEqual(
+            'let Foo = styled("div")``;\nFoo.displayName = "styled(Foo)";'
+        );
+    });
+    it('only works for styled expressions', () => {
+        expect(transform('const Foo = foo("div")``', { dev: true })).toEqual(
+            'const Foo = foo("div")``;'
+        );
+    });
+    it('skip transform if not in dev mode', () => {
+        expect(transform('const Foo = foo("div")``')).toEqual('const Foo = foo("div")``;');
+    });
+});

--- a/packages/babel-plugin-transform-goober/__tests__/index.test.js
+++ b/packages/babel-plugin-transform-goober/__tests__/index.test.js
@@ -7,7 +7,7 @@ function transform(input, options = {}) {
     return _transform(input, {
         babelrc: false,
         configFile: false,
-        plugins: [[plugin, options]]
+        plugins: [[plugin, { pure: false, ...options }]]
     }).code;
 }
 
@@ -16,7 +16,7 @@ function transformFile(fixture, options = {}) {
     return _transformFileSync(file, {
         babelrc: false,
         configFile: false,
-        plugins: [[plugin, options]]
+        plugins: [[plugin, { pure: false, ...options }]]
     }).code;
 }
 

--- a/packages/babel-plugin-transform-goober/index.js
+++ b/packages/babel-plugin-transform-goober/index.js
@@ -12,7 +12,6 @@ function prependPureComment(node) {
 
 module.exports = function ({ types: t }, options = {}) {
     const name = options.name || 'styled';
-    const dev = options.dev || false;
 
     return {
         name: 'transform-goober',
@@ -30,22 +29,26 @@ module.exports = function ({ types: t }, options = {}) {
                         prependPureComment(path.node);
                     }
 
-                    if (!dev) return;
-                    // Add displayName to goober components for easier debugging
-                    const variable = path.findParent((path) => path.isVariableDeclaration());
-                    if (variable && variable.node.declarations.length === 1) {
-                        const decl = variable.node.declarations[0];
+                    if (options.displayName) {
+                        // Add displayName to goober components for easier debugging
+                        const variable = path.findParent((path) => path.isVariableDeclaration());
+                        if (variable && variable.node.declarations.length === 1) {
+                            const decl = variable.node.declarations[0];
 
-                        if (t.isIdentifier(decl.id)) {
-                            variable.insertAfter(
-                                t.expressionStatement(
-                                    t.assignmentExpression(
-                                        '=',
-                                        t.MemberExpression(decl.id, t.identifier('displayName')),
-                                        t.stringLiteral(`${name}(${decl.id.name})`)
+                            if (t.isIdentifier(decl.id)) {
+                                variable.insertAfter(
+                                    t.expressionStatement(
+                                        t.assignmentExpression(
+                                            '=',
+                                            t.MemberExpression(
+                                                decl.id,
+                                                t.identifier('displayName')
+                                            ),
+                                            t.stringLiteral(`${name}(${decl.id.name})`)
+                                        )
                                     )
-                                )
-                            );
+                                );
+                            }
                         }
                     }
                 }

--- a/packages/babel-plugin-transform-goober/index.js
+++ b/packages/babel-plugin-transform-goober/index.js
@@ -18,20 +18,22 @@ function createAssignment(t, left, right) {
 
 module.exports = function ({ types: t }, options = {}) {
     const name = options.name || 'styled';
+    // Enable pure by default if it is not set by the user
+    const pure = !('pure' in options) ? true : options.pure;
 
     return {
         name: 'transform-goober',
         visitor: {
             TaggedTemplateExpression(path, state) {
                 if (t.isIdentifier(path.node.tag) && path.node.tag.name === 'css') {
-                    if (options.pure) {
+                    if (pure) {
                         prependPureComment(path.node);
                     }
                 } else if (
                     t.isIdentifier(path.node.tag.callee) &&
                     path.node.tag.callee.name === name
                 ) {
-                    if (options.pure) {
+                    if (pure) {
                         prependPureComment(path.node);
                     }
 
@@ -96,7 +98,7 @@ module.exports = function ({ types: t }, options = {}) {
 
                     path.replaceWith(t.callExpression(node.object, [property]));
 
-                    if (options.pure) {
+                    if (pure) {
                         prependPureComment(path.node);
                     }
                 }

--- a/packages/babel-plugin-transform-goober/index.js
+++ b/packages/babel-plugin-transform-goober/index.js
@@ -48,7 +48,7 @@ module.exports = function ({ types: t }, options = {}) {
                                     createAssignment(
                                         t,
                                         t.MemberExpression(decl.id, t.identifier('displayName')),
-                                        t.stringLiteral(`${name}(${decl.id.name})`)
+                                        t.stringLiteral(decl.id.name)
                                     )
                                 );
 

--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -153,4 +153,14 @@ describe('styled', () => {
         expect(styleFn).toHaveBeenCalledWith(Object.assign({ className: 'css()' }, p));
         expect(_h).toBeCalledWith('tag', Object.assign({}, p, { className: 'css()' }));
     });
+
+    it('uses babel compiled classNames', () => {
+        const _h = jest.fn().mockReturnValue('h()');
+        setup(_h);
+
+        const Comp = styled('tag')``;
+        Comp.className = 'foobar';
+        Comp({});
+        expect(_h).toBeCalledWith('tag', { className: 'css() foobar' });
+    });
 });

--- a/src/styled.js
+++ b/src/styled.js
@@ -26,7 +26,7 @@ function styled(tag, forwardRef) {
             // Grab a shallow copy of the props
             // _ctx.p: is the props sent to the context
             let _props = (_ctx.p = Object.assign({ theme: useTheme && useTheme() }, props));
-            let _previousClassName = _props.className;
+            let _previousClassName = _props.className || Styled.className;
 
             // Set a flag if the current components had a previous className
             // similar to goober. This is the append/prepend flag


### PR DESCRIPTION
This PR adds several features to the `babel-plugin-transform-goober` plugin.

## `#__PURE__`-Annotations

Minifiers have a hard time knowing if a `styled()` call has a side-effect or not. To avoid generating invalid code they side with caution and won't remove unused components.

```js
// Final bundle, Foo is still there despite it not being used anywhere
const Foo = styled("div")``;

export function Bar() {
  return <div />
}
```


By adding a `#__PURE__` comment just before the call expression we can signal minifiers that the next statement has no side effects.

```js
// Before minification
const Foo = /*#__PURE__*/ styled("div")``;

export function Bar() {
  return <div />
}
```

After:

```js
// Final bundle, Foo is gone
export function Bar() {
  return <div />
}
```

This is enabled by default as I can hardly come up with a scenario where one wouldn't want this behavior. The user can opt out by setting `pure: false`.

## Richer component names in Preact devtools

Currently the name of a component will be inferred in this order for function and class components:

1. `fnOrClass.displayName`
2. `fnOrClass.name`
3. `Unknown`

The minified function name that's published on npm is called `a` and therefore every goober component would show up as `a` inside the devtools. By supplying a richer `displayName` the component names become less cryptic in the devtools.

Before:

![Screenshot from 2020-07-18 18-14-13](https://user-images.githubusercontent.com/1062408/87856889-896e4e00-c922-11ea-84fc-aa761a463cb8.png)

After:

![Screenshot from 2020-07-18 18-12-56](https://user-images.githubusercontent.com/1062408/87856895-912df280-c922-11ea-8397-1170a4f6ab5a.png)


This can be enabled by passing `displayName: true` to the babel plugin options.

## Richer CSS class names

While it's nice to have richer names in Preact Devtools, I find myself spending more time with the native elements panel when I'm focusing on the design. So it'd be nice to see which node is coming from which component. To do that the plugin will now add additional CSS classes that show where a component is coming from. They don't set any styles or anything. This is best illustrated with a quick example:

```js
// Before
<div className="go12312323" />

// After
<div className="Button__Icon-go-2 go12312323" />
```

The format for the generated className is `[FILENAME]__[COMPONENT]-go-[#]`.

This can be enabled by passing `displayName: true` to the babel plugin options.