### PR TITLE
Add support for parsing multiline CSS comments

### DIFF
--- a/src/core/__tests__/astish.test.js
+++ b/src/core/__tests__/astish.test.js
@@ -132,4 +132,40 @@ describe('astish', () => {
             }
         });
     });
+
+    it('should strip comments', () => {
+        expect(
+            astish(`
+                color: red;
+                /*
+                    some comment
+                */
+                transform: translate3d(0, 0, 0);
+                /**
+                 * other comment
+                 */
+                background: peachpuff;
+                font-size: xx-large; /* inline comment */
+                /* foo: bar */
+                font-weight: bold;
+            `)
+        ).toEqual({
+            color: 'red',
+            transform: 'translate3d(0, 0, 0)',
+            background: 'peachpuff',
+            'font-size': 'xx-large',
+            'font-weight': 'bold'
+        });
+    });
+
+    it('should parse multiline background declaration', () => {
+        expect(
+            astish(`
+                background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="white"><path d="M7.5 36.7h58.4v10.6H7.5V36.7zm0-15.9h58.4v10.6H7.5V20.8zm0 31.9h58.4v10.6H7.5V52.7zm0 15.9h58.4v10.6H7.5V68.6zm63.8-15.9l10.6 15.9 10.6-15.9H71.3zm21.2-5.4L81.9 31.4 71.3 47.3h21.2z"/></svg>')
+                    center/contain;
+            `)
+        ).toEqual({
+            background: `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="white"><path d="M7.5 36.7h58.4v10.6H7.5V36.7zm0-15.9h58.4v10.6H7.5V20.8zm0 31.9h58.4v10.6H7.5V52.7zm0 15.9h58.4v10.6H7.5V68.6zm63.8-15.9l10.6 15.9 10.6-15.9H71.3zm21.2-5.4L81.9 31.4 71.3 47.3h21.2z"/></svg>')center/contain`
+        });
+    });
 });

--- a/src/core/astish.js
+++ b/src/core/astish.js
@@ -1,5 +1,5 @@
 let newRule = /(?:([a-z0-9-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(})/gi;
-let ruleClean = /\/\*.*?\*\/|\s{2,}|\n/gm;
+let ruleClean = /\/\*+(?:.|[\n])*?\*\/|\s{2,}|\n/gm;
 
 /**
  * Convert a css style string into a object

--- a/src/core/astish.js
+++ b/src/core/astish.js
@@ -1,5 +1,5 @@
 let newRule = /(?:([a-z0-9-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(})/gi;
-let ruleClean = /\/\*+(?:.|\n)*?\*\/|\s{2,}|\n/gm;
+let ruleClean = /\/\*[\s\S]*?\*\/|\s{2,}|\n/gm;
 
 /**
  * Convert a css style string into a object

--- a/src/core/astish.js
+++ b/src/core/astish.js
@@ -1,5 +1,5 @@
 let newRule = /(?:([a-z0-9-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(})/gi;
-let ruleClean = /\/\*+(?:.|[\n])*?\*\/|\s{2,}|\n/gm;
+let ruleClean = /\/\*+(?:.|\n)*?\*\/|\s{2,}|\n/gm;
 
 /**
  * Convert a css style string into a object


### PR DESCRIPTION
This PR adds support for parsing multiline comments inside the CSS string. Previously they were not stripped and would trip up our parser, leading to invalid CSS.