### PR TITLE
Add support for parsing sibling selectors

### DIFF
--- a/src/core/__tests__/astish.test.js
+++ b/src/core/__tests__/astish.test.js
@@ -132,4 +132,31 @@ describe('astish', () => {
             }
         });
     });
+
+    it('parse multiline selectors', () => {
+        expect(
+            astish(`
+                .foo {
+                    :hover,
+                    :active,
+                    :focus {
+                        color: red;
+
+                        span {
+                            color: blue;
+                        }
+                    }
+                }
+            `)
+        ).toEqual({
+            '.foo': {
+                ':hover,:active,:focus': {
+                    color: 'red',
+                    span: {
+                        color: 'blue'
+                    }
+                }
+            }
+        });
+    });
 });

--- a/src/core/__tests__/parse.test.js
+++ b/src/core/__tests__/parse.test.js
@@ -184,7 +184,7 @@ describe('parse', () => {
         ).toEqual(['@supports (some: 1px){@media (s: 1){hush{display:flex;}}}']);
     });
 
-    it.skip('nested with multiple selector', () => {
+    it('nested with multiple selector', () => {
         const out = parse(
             {
                 display: 'value',
@@ -200,8 +200,10 @@ describe('parse', () => {
         expect(out).toEqual(
             [
                 'hush{display:value;}',
-                'hush:hover,hush:focus{border:0;}',
-                'hush:hover span,hush:focus span{index:unset;}'
+                'hush:hover{border:0;}',
+                'hush:hover span{index:unset;}',
+                'hush:focus{border:0;}',
+                'hush:focus span{index:unset;}'
             ].join('')
         );
     });

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -35,7 +35,9 @@ export let parse = (obj, paren, wrapper) => {
                 blocks += key + '{' + parse(val, '', '') + '}';
             } else {
                 // Call the parse for this block
-                blocks += parse(val, next, next == paren ? key : wrapper || '');
+                next.split(/,/g).some((sib) => {
+                    blocks += parse(val, sib, sib == paren ? key : wrapper || '');
+                });
             }
         } else {
             if (/^@i/.test(key)) {


### PR DESCRIPTION
This PR adds support for parsing sibling selectors:

```css
.foo {
  :hover,
  :active,
  :focus {
      color: red;

      span {
          color: blue;
      }
  }
}
```