### PR TITLE
(feat) keyframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ I always wondered, if you can get a working solution for css-in-js with a smalle
     -   [targets](#targets)
     -   [extractCss](#extractcsstarget)
     -   [glob](#glob)
+    -   [keyframes](#keyframes)
 -   [Integrations](#integrations)
     -   [Babel Plugin](#babel-plugin)
     -   [Gatsby](#gatsby)
@@ -248,10 +249,11 @@ const CustomButton = (props) => (
 
 ```js
 import { css } from 'goober';
-const BtnClassName = props => css({
-    background: props.color,
-    borderRadius: props.radius + 'px'
-});
+const BtnClassName = (props) =>
+    css({
+        background: props.color,
+        borderRadius: props.radius + 'px'
+    });
 ```
 
 **Notice:** using `css` with object can reduce your bundle size.
@@ -319,6 +321,30 @@ glob`
   * {
     box-sizing: border-box;
   }
+`;
+```
+
+### `keyframes`
+
+`keyframes` is a helpful method to define reusable animations that can be decoupled from the main style declaration and shared across components.
+
+```js
+import { keyframes } from 'goober';
+
+const rotate = keyframes`
+    from, to {
+        transform: rotate(0deg);
+    }
+
+    50% {
+        transform: rotate(180deg);
+    }
+`;
+
+const Wicked = styled('div')`
+    background: tomato;
+    color: white;
+    animation: ${rotate} 1s ease-in-out;
 `;
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "goober",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goober",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A less than 1KB css-in-js solution",
   "sideEffects": false,
   "main": "dist/goober.js",

--- a/src/__tests__/css.test.js
+++ b/src/__tests__/css.test.js
@@ -1,4 +1,4 @@
-import { css, glob } from '../css';
+import { css, glob, keyframes } from '../css';
 import { hash } from '../core/hash';
 import { compile } from '../core/compile';
 import { getSheet } from '../core/get-sheet';
@@ -31,14 +31,14 @@ describe('css', () => {
 
         expect(compile).toBeCalledWith(['base', ''], [1], undefined);
         expect(getSheet).toBeCalled();
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined);
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined, undefined);
         expect(out).toEqual('hash()');
     });
 
     it('args: object', () => {
         const out = css({ foo: 1 });
 
-        expect(hash).toBeCalledWith({ foo: 1 }, 'getSheet()', undefined, undefined);
+        expect(hash).toBeCalledWith({ foo: 1 }, 'getSheet()', undefined, undefined, undefined);
         expect(compile).not.toBeCalled();
         expect(getSheet).toBeCalled();
         expect(out).toEqual('hash()');
@@ -46,9 +46,9 @@ describe('css', () => {
 
     it('args: function', () => {
         const incoming = { foo: 'foo' };
-        const out = css.call({ p: incoming }, props => ({ foo: props.foo }));
+        const out = css.call({ p: incoming }, (props) => ({ foo: props.foo }));
 
-        expect(hash).toBeCalledWith(incoming, 'getSheet()', undefined, undefined);
+        expect(hash).toBeCalledWith(incoming, 'getSheet()', undefined, undefined, undefined);
         expect(compile).not.toBeCalled();
         expect(getSheet).toBeCalled();
         expect(out).toEqual('hash()');
@@ -64,7 +64,7 @@ describe('css', () => {
             g
         })`foo: 1`;
 
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', true, undefined);
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', true, undefined, undefined);
         expect(compile).toBeCalledWith(['foo: 1'], [], p);
         expect(getSheet).toBeCalledWith(target);
         expect(out).toEqual('hash()');
@@ -78,6 +78,17 @@ describe('glob', () => {
 
     it('args: g', () => {
         glob`a:b`;
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', 1, undefined);
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', 1, undefined, undefined);
+    });
+});
+
+describe('keyframes', () => {
+    it('type', () => {
+        expect(typeof keyframes).toEqual('function');
+    });
+
+    it('args: k', () => {
+        keyframes`a:b`;
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined, 1);
     });
 });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -6,6 +6,7 @@ describe('goober', () => {
             'css',
             'extractCss',
             'glob',
+            'keyframes',
             'setup',
             'styled'
         ]);

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -1,6 +1,6 @@
 import { h, createContext, render } from 'preact';
 import { useContext, forwardRef } from 'preact/compat';
-import { setup, styled } from '../index';
+import { setup, styled, keyframes } from '../index';
 import { extractCss } from '../core/update';
 
 describe('integrations', () => {
@@ -36,6 +36,21 @@ describe('integrations', () => {
         `
         );
 
+        const fadeAnimation = keyframes`
+            0% {
+                opacity: 0;
+            }
+            99% {
+                opacity: 1;
+                color: dodgerblue;
+            }
+        `;
+
+        const BoxWithAnimation = styled('span')`
+            opacity: 0;
+            animation: ${fadeAnimation} 500ms ease-in-out;
+        `;
+
         const refSpy = jest.fn();
 
         render(
@@ -49,13 +64,24 @@ describe('integrations', () => {
                     <BoxWithThemeColorFn />
                     <BoxWithThemeColor theme={{ color: 'green' }} />
                     <BoxWithThemeColorFn theme={{ color: 'orange' }} />
+                    <BoxWithAnimation />
                 </div>
             </ThemeContext.Provider>,
             target
         );
 
         expect(extractCss()).toMatchInlineSnapshot(
-            `" .go3865451590{color:red;}.go1925576363{color:blue;}.go3206651468{color:green;}.go4276997079{color:orange;}"`
+            [
+                '"',
+                ' ', // Empty white space that holds the textNode that the styles are appended
+                '@keyframes go384228713{0%{opacity:0;}99%{opacity:1;color:dodgerblue;}}',
+                '.go3865451590{color:red;}',
+                '.go1925576363{color:blue;}',
+                '.go3206651468{color:green;}',
+                '.go4276997079{color:orange;}',
+                '.go2069586824{opacity:0;animation:go384228713 500ms ease-in-out;}',
+                '"'
+            ].join('')
         );
 
         expect(refSpy).toHaveBeenCalledWith(

--- a/src/core/__tests__/hash.test.js
+++ b/src/core/__tests__/hash.test.js
@@ -69,6 +69,17 @@ describe('hash', () => {
         expect(res).toEqual('toHash()');
     });
 
+    it('regression: keyframes', () => {
+        const res = hash('keyframes', 'target', undefined, undefined, 1);
+
+        expect(toHash).toBeCalledWith('keyframes');
+        expect(astish).not.toBeCalled();
+        expect(parse).not.toBeCalled();
+        expect(update).toBeCalledWith('parse()', 'target', undefined);
+
+        expect(res).toEqual('toHash()');
+    });
+
     it('regression: object', () => {
         const className = Math.random() + 'unique';
         toHash.mockReturnValue(className);

--- a/src/core/__tests__/parse.test.js
+++ b/src/core/__tests__/parse.test.js
@@ -65,6 +65,20 @@ describe('parse', () => {
                         baz: '1px',
                         foo: '1px'
                     }
+                },
+                '@keyframes complex': {
+                    'from, 20%, 53%, 80%, to': {
+                        transform: 'translate3d(0,0,0)'
+                    },
+                    '40%, 43%': {
+                        transform: 'translate3d(0, -30px, 0)'
+                    },
+                    '70%': {
+                        transform: 'translate3d(0, -15px, 0)'
+                    },
+                    '90%': {
+                        transform: 'translate3d(0,-4px,0)'
+                    }
                 }
             },
             'hush'
@@ -73,7 +87,8 @@ describe('parse', () => {
         expect(out).toEqual(
             [
                 '@keyframes superAnimation{11.1%{opacity:0.9999;}111%{opacity:1;}}',
-                '@keyframes foo{to{baz:1px;foo:1px;}}'
+                '@keyframes foo{to{baz:1px;foo:1px;}}',
+                '@keyframes complex{from, 20%, 53%, 80%, to{transform:translate3d(0,0,0);}40%, 43%{transform:translate3d(0, -30px, 0);}70%{transform:translate3d(0, -15px, 0);}90%{transform:translate3d(0,-4px,0);}}'
             ].join('')
         );
     });

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -17,7 +17,7 @@ let stringify = (data) => {
     let out = '';
 
     for (let p in data) {
-        const val = data[p];
+        let val = data[p];
         out += p + (typeof val == 'object' ? stringify(data[p]) : data[p]);
     }
 

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -34,21 +34,24 @@ let stringify = (data) => {
  * @returns {String}
  */
 export let hash = (compiled, sheet, global, append, keyframes) => {
-    let ast = compiled[0] ? astish(compiled) : compiled;
-    let stringifiedCompiled = stringify(ast);
+    let stringifiedCompiled = typeof compiled == 'object' ? stringify(compiled) : compiled;
     let className =
         cache[stringifiedCompiled] || (cache[stringifiedCompiled] = toHash(stringifiedCompiled));
 
-    // If we are in _keyframes_ mode, define the wrapper for it
-    if (keyframes) {
-        ast = { ['@keyframes ' + className]: ast };
+    // If not
+    if (!cache[className]) {
+        // Build the _ast_-ish structure if needed
+        let ast = typeof compiled === 'object' ? compiled : astish(compiled);
+
+        // Parse it
+        cache[className] = parse(
+            keyframes ? { ['@keyframes ' + className]: ast } : ast,
+            global ? '' : '.' + className
+        );
     }
 
-    // Parse the compiled
-    let parsed = cache[className] || (cache[className] = parse(ast, global ? '' : '.' + className));
-
     // add or update
-    update(parsed, sheet, append);
+    update(cache[className], sheet, append);
 
     // return hash
     return className;

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -34,17 +34,21 @@ let stringify = (data) => {
  * @returns {String}
  */
 export let hash = (compiled, sheet, global, append, keyframes) => {
+    // Get a string representation of the object or the value that is called 'compiled'
     let stringifiedCompiled = typeof compiled == 'object' ? stringify(compiled) : compiled;
+
+    // Retrieve the className from cache or hash it in place
     let className =
         cache[stringifiedCompiled] || (cache[stringifiedCompiled] = toHash(stringifiedCompiled));
 
-    // If not
+    // If there's no entry for the current className
     if (!cache[className]) {
         // Build the _ast_-ish structure if needed
-        let ast = typeof compiled === 'object' ? compiled : astish(compiled);
+        let ast = typeof compiled == 'object' ? compiled : astish(compiled);
 
         // Parse it
         cache[className] = parse(
+            // For keyframes
             keyframes ? { ['@keyframes ' + className]: ast } : ast,
             global ? '' : '.' + className
         );

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -30,21 +30,22 @@ let stringify = (data) => {
  * @param {Object} sheet StyleSheet target
  * @param {Object} global Global flag
  * @param {Boolean} append Append or not
+ * @param {Boolean} keyframes Keyframes mode. The input is the keyframes body that needs to be wrapped.
  * @returns {String}
  */
-export let hash = (compiled, sheet, global, append) => {
-    // generate hash
-    let stringifiedCompiled = compiled.toLowerCase ? compiled : stringify(compiled);
+export let hash = (compiled, sheet, global, append, keyframes) => {
+    let ast = compiled[0] ? astish(compiled) : compiled;
+    let stringifiedCompiled = stringify(ast);
     let className =
         cache[stringifiedCompiled] || (cache[stringifiedCompiled] = toHash(stringifiedCompiled));
 
+    // If we are in _keyframes_ mode, define the wrapper for it
+    if (keyframes) {
+        ast = { ['@keyframes ' + className]: ast };
+    }
+
     // Parse the compiled
-    let parsed =
-        cache[className] ||
-        (cache[className] = parse(
-            compiled[0] ? astish(compiled) : compiled,
-            global ? '' : '.' + className
-        ));
+    let parsed = cache[className] || (cache[className] = parse(ast, global ? '' : '.' + className));
 
     // add or update
     update(parsed, sheet, append);

--- a/src/core/to-hash.js
+++ b/src/core/to-hash.js
@@ -5,6 +5,7 @@
  * The intermediate and final results are truncated into 32-bit
  * unsigned integers.
  * @param {String} str
+ * @returns {String}
  */
 export let toHash = (str) =>
     'go' + str.split('').reduce((out, i) => (101 * out + i.charCodeAt(0)) >>> 0, 11);

--- a/src/css.js
+++ b/src/css.js
@@ -14,7 +14,8 @@ function css(val) {
         _val.map ? compile(_val, [].slice.call(arguments, 1), ctx.p) : _val,
         getSheet(ctx.target),
         ctx.g,
-        ctx.o
+        ctx.o,
+        ctx.k
     );
 }
 
@@ -23,4 +24,6 @@ function css(val) {
  */
 let glob = css.bind({ g: 1 });
 
-export { css, glob };
+let keyframes = css.bind({ k: 1 });
+
+export { css, glob, keyframes };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export { styled, setup } from './styled';
 export { extractCss } from './core/update';
-export { css, glob } from './css';
+export { css, glob, keyframes } from './css';


### PR DESCRIPTION
This one adds support for `keyframes` function, same thing as `glob` but, this one hashes the animation names so one could reuse the same animations if wanted.

Could be used in all sorts of ways, as an example:
```js
import { keyframes, css } from 'goober';

const fade = keyframes`
  to {
    opacity: 1;
  }
`;

const cls = css`
  opacity: 0.5;

  &:hover {
    animation: 1s ${fade} ease-out;
  }
`;
```

Still need to sort out:
- [x] Tests
- [ ] Size shavings
- [x] Update documentation
- [ ] Think about moving `glob` and `keyframes` into separate entry points. So they won't affect the core size but I am not sure about it.