### PR TITLE
(feat) Add support for object outputs in tagged templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "goober",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goober",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A less than 1KB css-in-js solution",
   "sideEffects": false,
   "main": "dist/goober.js",

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -16,6 +16,14 @@ describe('integrations', () => {
             color: red;
         `;
 
+        const SpanWrapper = styled('div')`
+            color: cyan;
+
+            ${Span} {
+                border: 1px solid red;
+            }
+        `;
+
         const BoxWithColor = styled('div')`
             color: ${(props) => props.color};
         `;
@@ -58,6 +66,9 @@ describe('integrations', () => {
                 <div>
                     <Span ref={refSpy} />
                     <Span as={'div'} />
+                    <SpanWrapper>
+                        <Span />
+                    </SpanWrapper>
                     <BoxWithColor color={'red'} />
                     <BoxWithColorFn color={'red'} />
                     <BoxWithThemeColor />
@@ -76,6 +87,8 @@ describe('integrations', () => {
                 ' ', // Empty white space that holds the textNode that the styles are appended
                 '@keyframes go384228713{0%{opacity:0;}99%{opacity:1;color:dodgerblue;}}',
                 '.go3865451590{color:red;}',
+                '.go3991234422{color:cyan;}',
+                '.go3991234422 .go3865451590{border:1px solid red;}',
                 '.go1925576363{color:blue;}',
                 '.go3206651468{color:green;}',
                 '.go4276997079{color:orange;}',

--- a/src/core/__tests__/compile.test.js
+++ b/src/core/__tests__/compile.test.js
@@ -1,7 +1,7 @@
 import { compile } from '../compile';
 
 const template = (str, ...defs) => {
-    return props => compile(str, defs, props);
+    return (props) => compile(str, defs, props);
 };
 
 describe('compile', () => {
@@ -25,5 +25,29 @@ describe('compile', () => {
     it('value interpolations', () => {
         // This interpolations are testing the ability to interpolate thruty and falsy values
         expect(template`prop: 1; ${() => 0},${() => undefined},${2}`({})).toEqual('prop: 1; 0,,2');
+    });
+
+    describe('objects', () => {
+        it('normal', () => {
+            expect(template`prop: 1;${(p) => ({ color: p.color })}`({ color: 'red' })).toEqual(
+                'prop: 1;color:red;'
+            );
+        });
+
+        it('styled-system', () => {
+            const color = (p) => ({ color: p.color });
+            const background = (p) => ({ backgroundColor: p.backgroundColor });
+
+            const props = { color: 'red', backgroundColor: 'blue' };
+            const res = template`
+                prop: 1;
+                ${color}
+                ${background}
+            `(props);
+
+            expect(res.replace(/([\s|\n]+)/gm, '').trim()).toEqual(
+                'prop:1;color:red;background-color:blue;'
+            );
+        });
     });
 });

--- a/src/core/__tests__/compile.test.js
+++ b/src/core/__tests__/compile.test.js
@@ -15,7 +15,7 @@ describe('compile', () => {
         );
 
         // Empty or falsy
-        expect(template`prop: 1; ${() => ({ props: {} })}`({})).toEqual('prop: 1; ');
+        expect(template`prop: 1; ${() => ({ props: { foo: 1 } })}`({})).toEqual('prop: 1; ');
     });
 
     it('vanilla classname', () => {
@@ -24,7 +24,9 @@ describe('compile', () => {
 
     it('value interpolations', () => {
         // This interpolations are testing the ability to interpolate thruty and falsy values
-        expect(template`prop: 1; ${() => 0},${() => undefined},${2}`({})).toEqual('prop: 1; 0,,2');
+        expect(template`prop: 1; ${() => 0},${() => undefined},${() => null},${2}`({})).toEqual(
+            'prop: 1; 0,,,2'
+        );
     });
 
     describe('objects', () => {

--- a/src/core/compile.js
+++ b/src/core/compile.js
@@ -1,3 +1,5 @@
+import { parse } from './parse';
+
 /**
  * Can parse a compiled string, from a tagged template
  * @param {String} value
@@ -24,8 +26,8 @@ export let compile = (str, defs, data) => {
                   '.' + end
                 : // If `res` it's not falsy and not a vnode, we could just dump it
                 // since the value it's an dynamic value
-                res && res.props
-                ? ''
+                res && typeof res == 'object'
+                ? parse(res, '')
                 : res;
         }
         return out + next + (tail == null ? '' : tail);

--- a/src/core/compile.js
+++ b/src/core/compile.js
@@ -21,14 +21,17 @@ export let compile = (str, defs, data) => {
             // previously styled className by checking the prefix
             let end = className || (/^go/.test(res) && res);
 
-            tail = end
-                ? // If the `end` is defined means it's a className
-                  '.' + end
-                : // If `res` it's not falsy and not a vnode, we could just dump it
-                // since the value it's an dynamic value
-                res && typeof res == 'object'
-                ? parse(res, '')
-                : res;
+            if (end) {
+                // If the `end` is defined means it's a className
+                tail = '.' + end;
+            } else if (res && typeof res == 'object') {
+                // If `res` it's an object, we're either dealing with a vnode
+                // or an object returned from a function interpolation
+                tail = res.props ? '' : parse(res, '');
+            } else {
+                // Regular value returned. Can be falsy as well
+                tail = res;
+            }
         }
         return out + next + (tail == null ? '' : tail);
     }, '');


### PR DESCRIPTION
This is handling the parsing of objects inside the tagged templates, by passing the `res` from the function call to the parse method.

Fixes #186 #136 