### PR TITLE
docs: extend setup api with prefixer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ I always wondered, if you can get a working solution for css-in-js with a smalle
 -   [API](#api)
     -   [styled](#styledtagname)
     -   [setup](#setpragmapragma-function)
+        -   [With prefixer](#with-prefixer)
+        -   [With theme](#with-theme)
     -   [css](#csstaggedtemplate)
     -   [targets](#targets)
     -   [extractCss](#extractcsstarget)
@@ -202,8 +204,19 @@ import { setup } from 'goober';
 
 setup(React.createElement);
 ```
+#### With prefixer
 
-With theme:
+```js
+import React from 'react';
+import { setup } from 'goober';
+
+const customPrefixer = (key, value) => `${key}: ${value};\n`;
+
+setup(React.createElement, customPrefixer);
+```
+
+#### With theme
+
 ```js
 import React from 'react';
 import { setup, styled } from 'goober';


### PR DESCRIPTION
Add an example in the README to showcase the setup with a prefixer.