### PR TITLE
Add support for theme TypeScript definitions

### DIFF
--- a/goober.d.ts
+++ b/goober.d.ts
@@ -5,10 +5,14 @@ export = goober;
 export as namespace goober;
 
 declare namespace goober {
+    interface DefaultTheme {}
+
+    type Theme<T extends object> = keyof T extends never ? T : { theme: T };
+
     interface StyledFunction {
         // used when creating a styled component from a native HTML element
         <T extends keyof JSX.IntrinsicElements, P extends Object = {}>(tag: T): Tagged<
-            JSX.LibraryManagedAttributes<T, JSX.IntrinsicElements[T]> & P
+            JSX.LibraryManagedAttributes<T, JSX.IntrinsicElements[T]> & P & Theme<DefaultTheme>
         >;
 
         // used to extend other styled components. Inherits props from the extended component
@@ -43,7 +47,7 @@ declare namespace goober {
         ...props: Array<
             string | number | ((props: P & PP) => CSSAttribute | string | number | undefined)
         >
-    ) => StyledVNode<P & PP>;
+    ) => StyledVNode<Omit<P & PP, keyof Theme<DefaultTheme>>>;
     interface CSSAttribute extends CSSProperties {
         [key: string]: CSSAttribute | string | number | undefined;
     }

--- a/ts-tests/test-api.tsx
+++ b/ts-tests/test-api.tsx
@@ -1,6 +1,15 @@
 import { h, ComponentChildren } from 'preact';
 import { styled, setup, css, glob } from '../goober';
 
+// This would be an ambient module declaration in the client's project
+declare module '../goober' {
+    export interface DefaultTheme {
+        colors: {
+            primary: string;
+        };
+    }
+}
+
 setup(h);
 
 const testStyledCss = () => {
@@ -57,6 +66,11 @@ const testStyledCss = () => {
         background: props.disabled ? 'gray' : 'tomato'
     }));
 
+    const ThemeContainer = styled('div')<{ isActive: boolean }>`
+        color: ${(props) => (props.isActive ? 'tomato' : 'dodgerblue')};
+        background-color: ${(props) => props.theme.colors.primary};
+    `;
+
     const TestComp = () => {
         return (
             <div>
@@ -73,6 +87,7 @@ const testStyledCss = () => {
                 <Childless />
                 <StyledHello name="you" />
                 <StyledObject disabled />
+                <ThemeContainer isActive={true} />
             </div>
         );
     };


### PR DESCRIPTION
By letting the user extend the `goober` TypeScript definitions it is possible to support theme types. Should be used in combination when using theme in `setup(X, X, theme)`.


It works as follows:
1) The user should create a declarations file, let's call it `goober.d.ts` (file name suggestions?)
```ts
import 'goober';

declare module 'goober' {
    export interface DefaultTheme {
        colors: {
            primary: string;
        };
    }
}
```
2) Use it like you should normally do (but with "autocomplete")
```js
const ThemeContainer = styled('div')`
     background-color: ${(props) => props.theme.colors.primary};
`;
```
`DefaultTheme` is being used as an interface of `props.theme` out of the box.




If this PR gets approved, I think this should be moved to a section in the `README`.

Inspiration: https://styled-components.com/docs/api#create-a-declarations-file