### PR TITLE
Add the types for forwardRef argument to styled()

### DIFF
--- a/goober.d.ts
+++ b/goober.d.ts
@@ -7,20 +7,31 @@ export as namespace goober;
 declare namespace goober {
     interface StyledFunction {
         // used when creating a styled component from a native HTML element
-        <T extends keyof JSX.IntrinsicElements, P extends Object = {}>(tag: T): Tagged<
-            JSX.LibraryManagedAttributes<T, JSX.IntrinsicElements[T]> & P
-        >;
+        <T extends keyof JSX.IntrinsicElements, P extends Object = {}>(
+            tag: T,
+            forwardRef?: ForwardRefFunction
+        ): Tagged<JSX.LibraryManagedAttributes<T, JSX.IntrinsicElements[T]> & P>;
 
         // used to extend other styled components. Inherits props from the extended component
-        <PP extends Object = {}, P extends Object = {}>(tag: StyledVNode<PP>): Tagged<PP & P>;
+        <PP extends Object = {}, P extends Object = {}>(
+            tag: StyledVNode<PP>,
+            forwardRef?: ForwardRefFunction
+        ): Tagged<PP & P>;
 
         // used when creating a component from a string (html native) but using a non HTML standard
         // component, such as when you want to style web components
         <P extends Object = {}>(tag: string): Tagged<P & Partial<JSX.ElementChildrenAttribute>>;
 
         // used to create a styled component from a JSX element (both functional and class-based)
-        <T extends JSX.Element | JSX.ElementClass, P extends Object = {}>(tag: T): Tagged<P>;
+        <T extends JSX.Element | JSX.ElementClass, P extends Object = {}>(
+            tag: T,
+            forwardRef?: ForwardRefFunction
+        ): Tagged<P>;
     }
+
+    type ForwardRefFunction = {
+        (props: any, ref: any): any;
+    };
 
     const styled: StyledFunction;
     function setup<T>(val: T, prefixer?: (key: string, val: any) => string, theme?: Function): void;

--- a/ts-tests/test-api.tsx
+++ b/ts-tests/test-api.tsx
@@ -1,4 +1,6 @@
 import { h, ComponentChildren } from 'preact';
+import { forwardRef as preactForwardRef } from 'preact/compat';
+import { forwardRef as reactForwardRef } from 'react';
 import { styled, setup, css, glob } from '../goober';
 
 setup(h);
@@ -76,6 +78,10 @@ const testStyledCss = () => {
             </div>
         );
     };
+
+    const ReactForwardRefTest = styled('div', reactForwardRef);
+
+    const PreactForwardRefTest = styled('div', preactForwardRef);
 };
 
 const testGlob = () => {


### PR DESCRIPTION
This adds updates the type declarations adding the types second argument to `styled()` - `forwardRef`.

I believe it's not possible to make the types more specific than a function that returns `any`

Fixes #176 