### PR TITLE
fix package entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/goober.module.js"
+      "browser": "./dist/goober.module.js",
+      "import": "./dist/goober.module.js",
+      "require": "./dist/goober.js",
+      "umd": "./dist/goober.umd.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
I was trying to use `goober` with `snowpack` when I started noticing [this error](https://github.com/snowpackjs/snowpack/discussions/1421).

As mentioned in [specs](https://nodejs.org/api/packages.html#packages_package_entry_points), It seems, when `exports` is present, we can not use `main` as a fallback.

This PR should fix the usage for snowpack and modern node versions.