### PR TITLE
(fix) makes sure the props are passed when extending

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "goober",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goober",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "A less than 1KB css-in-js solution",
   "sideEffects": false,
   "main": "dist/goober.js",

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -124,4 +124,57 @@ describe('integrations', () => {
             })
         );
     });
+
+    it('shouldForwardProps', () => {
+        const list = ['p', 'm', 'as'];
+        setup(h, undefined, undefined, (props) => {
+            for (let prop in props) {
+                if (list.indexOf(prop) !== -1) {
+                    delete props[prop];
+                }
+            }
+        });
+
+        const target = document.createElement('div');
+
+        const Base = styled('div')(({ p = 0, m }) => [
+            {
+                color: 'white',
+                padding: p + 'em'
+            },
+            m != null && { margin: m + 'em' }
+        ]);
+
+        render(
+            <div>
+                <Base />
+                <Base p={2} />
+                <Base m={1} p={3} as={'span'} />
+            </div>,
+            target
+        );
+
+        // Makes sure the resulting DOM does not contain any props
+        expect(target.innerHTML).toMatchInlineSnapshot(
+            [
+                '"',
+                '<div>',
+                '<div class="go103173764"></div>',
+                '<div class="go103194166"></div>',
+                '<span class="go2081835032"></span>',
+                '</div>',
+                '"'
+            ].join('')
+        );
+
+        expect(extractCss()).toMatchInlineSnapshot(
+            [
+                '"',
+                '.go103173764{color:white;padding:0em;}',
+                '.go103194166{color:white;padding:2em;}',
+                '.go2081835032{color:white;padding:3em;margin:1em;}',
+                '"'
+            ].join('')
+        );
+    });
 });

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -155,15 +155,13 @@ describe('integrations', () => {
         );
 
         // Makes sure the resulting DOM does not contain any props
-        expect(target.innerHTML).toMatchInlineSnapshot(
+        expect(target.innerHTML).toEqual(
             [
-                '"',
                 '<div>',
                 '<div class="go103173764"></div>',
                 '<div class="go103194166"></div>',
                 '<span class="go2081835032"></span>',
-                '</div>',
-                '"'
+                '</div>'
             ].join(''),
             `"<div><div class=\\"go103173764\\"></div><div class=\\"go103194166\\"></div><span class=\\"go2081835032\\"></span></div>"`
         );

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -164,7 +164,8 @@ describe('integrations', () => {
                 '<span class="go2081835032"></span>',
                 '</div>',
                 '"'
-            ].join('')
+            ].join(''),
+            `"<div><div class=\\"go103173764\\"></div><div class=\\"go103194166\\"></div><span class=\\"go2081835032\\"></span></div>"`
         );
 
         expect(extractCss()).toMatchInlineSnapshot(

--- a/src/styled.js
+++ b/src/styled.js
@@ -47,12 +47,15 @@ function styled(tag, forwardRef) {
                 _props.ref = ref;
             }
 
-            // Handle the forward props filter if defined
-            if (fwdProp) {
+            // Let the closure do the capture, cause it might get removed in the fwdProp
+            let _as = _props.as || tag;
+
+            // Handle the forward props filter if defined and _as is a string
+            if (fwdProp && _as[0]) {
                 fwdProp(_props);
             }
 
-            return h(_props.as || tag, _props);
+            return h(_as, _props);
         }
 
         return forwardRef ? forwardRef(Styled) : Styled;


### PR DESCRIPTION
Everything works as expected until you try to extend an styled component. So, in order to let the props pass through, until it arrives at the _real_ tag element, we should not call the fwdProp function. 👍 