### PR TITLE
Misc: Update Typescript Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ It's a pun on the tagline.
 -   [Features](#features)
     -   [Sharing Style](#sharing-style)
     -   [Autoprefixer](#autoprefixer)
+    -   [TypeScript](#typescript)
 -   [Browser Support](#browser-support)
 -   [Contributing](#contributing)
 
@@ -695,6 +696,56 @@ setup(React.createElement, prefix);
 ```
 
 And voila! It is done!
+
+# TypeScript
+
+`goober` comes with type definitions build in, making it easy to get started in TypeScript straight away.
+
+## Prop Types
+
+If you're utilising custom props and wish to style based on them, you can do so when initialising as follows:
+
+```ts
+interface Props {
+    size: number;
+}
+
+styled('div')<Props>`
+    border-radius: ${(props) => props.size}px;
+`;
+
+// This also works!
+
+styled<Props>('div')`
+    border-radius: ${(props) => props.size}px;
+`;
+```
+
+## Extending Theme
+
+If you're using a [custom theme](../api/setup.md#with-theme) with goober, to add types to it you should create a declaration file at the base of your project.
+
+```ts
+// goober.d.t.s
+
+import 'goober';
+
+declare module 'goober' {
+    export interface DefaultTheme {
+        colors: {
+            primary: string;
+        };
+    }
+}
+```
+
+You should now have autocompletion for your theme.
+
+```ts
+const ThemeContainer = styled('div')`
+    background-color: ${(props) => props.theme.colors.primary};
+`;
+```
 
 # Browser support
 

--- a/docs/docs/features/typescript.md
+++ b/docs/docs/features/typescript.md
@@ -1,0 +1,63 @@
+---
+id: typescript
+title: TypeScript
+sidebar_label: TypeScript
+---
+
+`goober` comes with types included, making developing with TypeScript easy.
+
+## Prop Types
+
+If you're utilising custom props and wish to style based on them, you can do so when initialising as follows:
+
+```ts
+interface Props {
+    size: number;
+}
+
+styled('div')<Props>`
+    border-radius: ${(props) => props.size}px;
+`;
+
+// This also works!
+
+styled<Props>('div')`
+    border-radius: ${(props) => props.size}px;
+`;
+```
+
+## Extending Theme
+
+If you're using a [custom theme](../api/setup.md#with-theme) with goober, to add types to it you should create a declaration file at the base of your project.
+
+```ts
+// goober.d.t.s
+
+import 'goober';
+
+declare module 'goober' {
+    export interface DefaultTheme {
+        colors: {
+            primary: string;
+        };
+    }
+}
+```
+
+You should now have autocompletion for your theme.
+
+```ts
+const ThemeContainer = styled('div')`
+    background-color: ${(props) => props.theme.colors.primary};
+`;
+```
+
+#### Note when using Preact
+
+If utilising Preact, add the following into a declaration file at the root of your project to enable typing:
+
+```ts
+// preact.d.ts
+
+import JSX = preact.JSX;
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -35,7 +35,12 @@ module.exports = {
             type: 'category',
             label: 'Features',
             collapsed: false,
-            items: ['features/checklist', 'features/sharing-style', 'features/autoprefixer']
+            items: [
+                'features/checklist',
+                'features/sharing-style',
+                'features/autoprefixer',
+                'features/typescript'
+            ]
         },
         {
             type: 'doc',


### PR DESCRIPTION
This PR adds basic typescript documentation to the README and to the Docs website. 

More specifically, it adds documentation regarding using a custom theme and defining typed prop types. In the documentation it also includes a note on defining types within Preact, but I felt this was unnecessary for the README.

I've added it under Features, but you may feel it belongs elsewhere.