### PR TITLE
Add Typings for Arrays of CSS Attributes

### DIFF
--- a/goober.d.ts
+++ b/goober.d.ts
@@ -67,6 +67,7 @@ declare namespace goober {
     type Tagged<P extends Object = {}> = <PP extends Object = {}>(
         tag:
             | CSSAttribute
+            | CSSAttribute[]
             | TemplateStringsArray
             | string
             | ((props: P & PP) => CSSAttribute | string),


### PR DESCRIPTION
When utilising TypeScript with Goober, and the array method of adding CSS attributes, like so:

```ts
import { styled } from 'goober'

styled('div')([{
  color: 'blue'
}])

```
TypeScript complains that an array cannot be used, however this is valid Goober syntax (see screenshot below).
![Screenshot 2021-02-27 at 15 46 53](https://user-images.githubusercontent.com/31065041/109392245-04fd9800-7913-11eb-8238-7018a6511955.png)

This PR adds the option for an array to passed as `CSSAttribute[]` to stop TypeScript complaining.


