### PR TITLE
Give preference to require main

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,16 +34,12 @@
   ],
   "exports": {
     ".": {
+      "require": "./dist/goober.js",
       "browser": "./dist/goober.modern.js",
       "import": "./dist/goober.esm.js",
-      "require": "./dist/goober.js",
       "umd": "./dist/goober.umd.js"
     },
-    "./macro": {
-      "browser": "./macro/index.js",
-      "import": "./macro/index.js",
-      "require": "./macro/index.js"
-    },
+    "./macro": "./macro/index.js",
     "./global": {
       "browser": "./global/dist/goober-global.modern.js",
       "import": "./global/dist/goober-global.esm.js",


### PR DESCRIPTION
This came up in https://github.com/jspm/project/issues/96 on jspm.dev for react-host-toast.

react-hot-toast contains:

```js
goober = require('goober');
```

When JSPM builds for the browser, it converts the above into:

```js
import goober from 'goober';
```

Per the Node.js semantics. But then uses the browser ESM version, which doesn't export a default export.

This ensures the require version is always used for CJS requires both in the browser and Node.js. An alternative could be to provide a default export in the ESM version as well.