### PR TITLE
Revert "Remove glob from core"

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ export default function App() {
 }
 ```
 
-#### How about using the `glob` function directly?
+#### How about using `glob` function directly?
 
 Before the global addon, `goober/global`, there was a method named `glob` that was part of the main package that would do the same thing, more or less. Having only that method to define global styles usually led to missing global styles from the extracted css, since the pattern did not enforced the evaluation of the styles at render time. The `glob` method it is still exported from `goober/global` if you have a hard dependency on it. It still has the same API:
 
@@ -624,7 +624,7 @@ Usage:
 -   [x] Styling any component
     -   via `` const Btn = ({className}) => {...}; const TomatoBtn = styled(Btn)`color: tomato;` ``
 -   [x] Vanilla(via `css` function)
--   [x] `globalStyle`(via `glob`, `createGlobalStyles`) so one would be able to create global styles
+-   [x] `globalStyle`(via `glob`) so one would be able to create global styles
 -   [x] target/extract from elements other than `<head>`
 -   [x] [vendor prefixing](#autoprefixer)
 

--- a/global/src/__tests__/global.test.js
+++ b/global/src/__tests__/global.test.js
@@ -1,5 +1,5 @@
 import { glob, createGlobalStyles } from '../index';
-import { css } from 'goober';
+import { css, setup } from 'goober';
 
 jest.mock('goober', () => ({
     css: jest.fn().mockReturnValue('css()')

--- a/src/__tests__/css.test.js
+++ b/src/__tests__/css.test.js
@@ -87,6 +87,17 @@ describe('css', () => {
     });
 });
 
+describe('glob', () => {
+    it('type', () => {
+        expect(typeof glob).toEqual('function');
+    });
+
+    it('args: g', () => {
+        glob`a:b`;
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', 1, undefined, undefined);
+    });
+});
+
 describe('keyframes', () => {
     it('type', () => {
         expect(typeof keyframes).toEqual('function');

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -5,6 +5,7 @@ describe('goober', () => {
         expect(Object.keys(goober).sort()).toEqual([
             'css',
             'extractCss',
+            'glob',
             'keyframes',
             'setup',
             'styled'

--- a/src/css.js
+++ b/src/css.js
@@ -26,9 +26,15 @@ function css(val) {
 }
 
 /**
+ * CSS Global function to declare global styles
+ * @type {Function}
+ */
+let glob = css.bind({ g: 1 });
+
+/**
  * `keyframes` function for defining animations
  * @type {Function}
  */
 let keyframes = css.bind({ k: 1 });
 
-export { css, keyframes };
+export { css, glob, keyframes };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export { styled, setup } from './styled';
 export { extractCss } from './core/update';
-export { css, keyframes } from './css';
+export { css, glob, keyframes } from './css';


### PR DESCRIPTION
Reverts cristianbote/goober#253 until a major version, since it's a API deprecation.