### PR TITLE
fix: Missing TS types for `styled` function (#275)

### DIFF
--- a/goober.d.ts
+++ b/goober.d.ts
@@ -64,13 +64,14 @@ declare namespace goober {
         ...props: Array<string | number>
     ): string;
     type StyledVNode<T> = (props: T, ...args: any[]) => any;
+    type StylesGenerator<P extends Object = {}> = (props: P) => CSSAttribute | string;
     type Tagged<P extends Object = {}> = <PP extends Object = {}>(
         tag:
             | CSSAttribute
-            | CSSAttribute[]
+            | (CSSAttribute | StylesGenerator<P & PP>)[]
             | TemplateStringsArray
             | string
-            | ((props: P & PP) => CSSAttribute | string),
+            | StylesGenerator<P & PP>,
         ...props: Array<
             | string
             | number

--- a/src/__tests__/css.test.js
+++ b/src/__tests__/css.test.js
@@ -45,11 +45,15 @@ describe('css', () => {
     });
 
     it('args: array', () => {
-        const payload = [{ foo: 1 }, { baz: 2 }, { opacity: 0, color: 'red' }];
+        const propsBased = jest.fn().mockReturnValue({
+            backgroundColor: 'gold'
+        });
+        const payload = [{ foo: 1 }, { baz: 2 }, { opacity: 0, color: 'red' }, propsBased];
         const out = css(payload);
 
+        expect(propsBased).toHaveBeenCalled();
         expect(hash).toBeCalledWith(
-            { foo: 1, baz: 2, opacity: 0, color: 'red' },
+            { foo: 1, baz: 2, opacity: 0, color: 'red', backgroundColor: 'gold' },
             'getSheet()',
             undefined,
             undefined,


### PR DESCRIPTION
- Fix #275 
- Add test to ensure functions are valid as array items for `css(...)`