### PR TITLE
Updates docs regarding setup() - once only - in entry file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ const Title = styled('h1', React.forwardRef)`
 
 ### `setup(pragma: Function, prefixer?: Function, theme?: Function, forwardProps?: Function)`
 
+The call to `setup()` should occur once only. It should be called in the entry file of you project.
+
 Given the fact that `react` uses `createElement` for the transformed elements and `preact` uses `h`, `setup` should be called with the proper _pragma_ function. This was added to reduce the bundled size and being able to bundle esmodule version. At the moment I think it's the best tradeoff we can have.
 
 ```js

--- a/docs/docs/api/setup.md
+++ b/docs/docs/api/setup.md
@@ -6,6 +6,8 @@ sidebar_label: setup
 
 `setup(pragma: Function, prefixer?: Function, theme?: Function, forwardProps?: Function)`
 
+The call to `setup()` should occur once only. It should be called in the entry file of you project.
+
 Given the fact that `react` uses `createElement` for the transformed elements and `preact` uses `h`, `setup` should be called with the proper _pragma_ function. This was added to reduce the bundled size and being able to bundle esmodule version. At the moment I think it's the best tradeoff we can have.
 
 ```js


### PR DESCRIPTION
Adds the following line to the docs on `setup()`:

The call to `setup()` should occur once only. It should be called in the entry file of you project.



