### PR TITLE
Rephrase a regexp in astish.js to shave off 5 bytes from the built bundle

### DIFF
--- a/src/core/astish.js
+++ b/src/core/astish.js
@@ -1,5 +1,5 @@
 let newRule = /(?:([A-Z0-9-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(})/gi;
-let ruleClean = /\/\*[^]*?\*\/|\s{2,}|\n/gm;
+let ruleClean = /\/\*[^]*?\*\/|\s\s+|\n/gm;
 
 /**
  * Convert a css style string into a object

--- a/src/core/astish.js
+++ b/src/core/astish.js
@@ -1,5 +1,5 @@
 let newRule = /(?:([A-Z0-9-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(})/gi;
-let ruleClean = /\/\*[^]*?\*\/|\s\s+|\n/gm;
+let ruleClean = /\/\*[^]*?\*\/|\s\s+|\n/g;
 
 /**
  * Convert a css style string into a object

--- a/src/core/astish.js
+++ b/src/core/astish.js
@@ -1,5 +1,5 @@
 let newRule = /(?:([A-Z0-9-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(})/gi;
-let ruleClean = /\/\*[\s\S]*?\*\/|\s{2,}|\n/gm;
+let ruleClean = /\/\*[^]*?\*\/|\s{2,}|\n/gm;
 
 /**
  * Convert a css style string into a object


### PR DESCRIPTION
This pull request shaves 5 bytes out of the minified + gzipped `goober.js.gz` file. The changes are all made to the `ruleClean` regular expression in the `src/core/astish.js` file:

 * Change `[\s\S]` to `[^]`. The original `[\s\S]` is there to match any character (I think), and `[^]` also means that (per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes).
 * Change `\s{2,}` to `\s\s+`.
 * Remove the `m` (multiline) flag from the regex, as it seems the regular expression is not dependent on the functionality that the multiline flag affects.