### PR TITLE
remove g flag from regex test

### DIFF
--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -21,7 +21,7 @@ export let parse = (obj, selector) => {
                       // Return the current selector with the key matching multiple selectors if any
                       return key.replace(/([^,])+/g, (k) => {
                           // If the current `k`(key) has a nested selector replace it
-                          if (/&/g.test(k)) return k.replace(/&/g, sel);
+                          if (/&/.test(k)) return k.replace(/&/g, sel);
 
                           // If there's a current selector concat it
                           return sel ? sel + ' ' + k : k;

--- a/src/styled.js
+++ b/src/styled.js
@@ -36,7 +36,7 @@ function styled(tag, forwardRef) {
             // Set a flag if the current components had a previous className
             // similar to goober. This is the append/prepend flag
             // The _empty_ space compresses better than `\s`
-            _ctx.o = / *go\d+/g.test(_previousClassName);
+            _ctx.o = / *go\d+/.test(_previousClassName);
 
             _props.className =
                 // Define the new className


### PR DESCRIPTION
g flag is counter-productive for .test() method with single use regex instances. one match should be conclusive.