### PR TITLE
Remove some variable usage

### DIFF
--- a/src/core/get-sheet.js
+++ b/src/core/get-sheet.js
@@ -12,14 +12,13 @@ export let getSheet = (target) => {
     if (typeof window !== 'undefined') {
         // Querying the existing target for a previously defined <style> tag
         // We're doing a querySelector because the <head> element doesn't implemented the getElementById api
-        let sheet = target ? target.querySelector('#' + GOOBER_ID) : window[GOOBER_ID];
-        if (!sheet) {
-            // Note to self: head.innerHTML +=, triggers a layout/reflow. Avoid it.
-            sheet = (target || document.head).appendChild(document.createElement('style'));
-            sheet.innerHTML = ' ';
-            sheet.id = GOOBER_ID;
-        }
-        return sheet.firstChild;
+        return (
+            (target ? target.querySelector('#' + GOOBER_ID) : window[GOOBER_ID]) ||
+            Object.assign((target || document.head).appendChild(document.createElement('style')), {
+                innerHTML: ' ',
+                id: GOOBER_ID
+            })
+        ).firstChild;
     }
     return target || ssr;
 };

--- a/src/core/to-hash.js
+++ b/src/core/to-hash.js
@@ -8,7 +8,8 @@
  * @returns {String}
  */
 export let toHash = (str) => {
-    let i = 0, l = str.length, out = 11;
-    while (i < l) out = (101 * out + str.charCodeAt(i++)) >>> 0
+    let i = 0,
+        out = 11;
+    while (i < str.length) out = (101 * out + str.charCodeAt(i++)) >>> 0;
     return 'go' + out;
-}
+};


### PR DESCRIPTION
From my local build, it's shave about >3b from `goober.js.gz` (and also from another file), let's see how the results in action.

What I'm doing:
1. Remove usage of `l` in `to-hash` since looks like it's just container for `str.length`
2. Remove usage of `sheet` in `get-sheet.js` since I think we could continue without using it