### PR TITLE
shrink style id prefix

### DIFF
--- a/src/core/get-sheet.js
+++ b/src/core/get-sheet.js
@@ -1,4 +1,4 @@
-let GOOBER_ID = '_goober';
+let GOOBER_ID = '_gbr';
 let ssr = {
     data: ''
 };


### PR DESCRIPTION
Are we up for shrinking down the id a bit?  We probably don't risk collisions too much by shrinking to `_gbr` and still can have an identifier that is readable.  We could go even smaller (`_gb` or `_g`) but it it worth sacrificing readability for size?