### PR TITLE
fix: Add a target argument to the extractCss typing

### DIFF
--- a/goober.d.ts
+++ b/goober.d.ts
@@ -50,7 +50,7 @@ declare namespace goober {
         theme?: Function,
         forwardProps?: ForwardPropsFunction
     ): void;
-    function extractCss(): string;
+    function extractCss(target?: Element): string;
     function glob(
         tag: CSSAttribute | TemplateStringsArray | string,
         ...props: Array<string | number>


### PR DESCRIPTION
extractCss() can receive a target argument, but d.ts does not support it.
https://github.com/cristianbote/goober#extractcsstarget