### PR TITLE
Code golf getSheet (-8B)

### DIFF
--- a/src/core/get-sheet.js
+++ b/src/core/get-sheet.js
@@ -9,7 +9,7 @@ let ssr = {
  * @returns {HTMLStyleElement|{data: ''}}
  */
 export let getSheet = (target) => {
-    if (typeof window !== 'undefined') {
+    if (typeof window === 'object') {
         // Querying the existing target for a previously defined <style> tag
         // We're doing a querySelector because the <head> element doesn't implemented the getElementById api
         return (
@@ -20,5 +20,6 @@ export let getSheet = (target) => {
             })
         ).firstChild;
     }
+
     return target || ssr;
 };


### PR DESCRIPTION
Glad I found out about the **The Great Shave Off Challenge** as I played with the idea that I wanted to contribute.

Here is a small optimization of the condition in the `getSheet` function, which saves some characters and removes exclamation mark to make compression better.

**Before:**

```
1173 B: goober.js.gz
1065 B: goober.js.br
1181 B: goober.modern.js.gz
1074 B: goober.modern.js.br
1181 B: goober.esm.js.gz
1074 B: goober.esm.js.br
1241 B: goober.umd.js.gz
1120 B: goober.umd.js.br
```

**Now:**

```
1165 B: goober.js.gz
1057 B: goober.js.br
1174 B: goober.modern.js.gz
1065 B: goober.modern.js.br
1174 B: goober.esm.js.gz
1065 B: goober.esm.js.br
1239 B: goober.umd.js.gz
1115 B: goober.umd.js.br
```

Difference: **-8B**

**Characters:**
Before: 2153
Now: 2150

**Where savings made:**
- **'undefined'** changed to **'object'**
- `!==` changed to `===`, which is bundled as `==` (no exclamation mark) and thus there are only `==` occurrences in the bundle and not a single `!=`