### PR TITLE
Code golf update (-2B)

### DIFF
--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -129,7 +129,7 @@ describe('integrations', () => {
         const list = ['p', 'm', 'as'];
         setup(h, undefined, undefined, (props) => {
             for (let prop in props) {
-                if (list.indexOf(prop) !== -1) {
+                if (list.includes(prop)) {
                     delete props[prop];
                 }
             }

--- a/src/core/update.js
+++ b/src/core/update.js
@@ -17,5 +17,5 @@ export let extractCss = (target) => {
  * @param {Boolean} append
  */
 export let update = (css, sheet, append) => {
-    sheet.data.indexOf(css) == -1 && (sheet.data = append ? css + sheet.data : sheet.data + css);
+    !sheet.data.includes(css) && (sheet.data = append ? css + sheet.data : sheet.data + css);
 };


### PR DESCRIPTION
This is a small improvement that shaves 2B. Together with https://github.com/cristianbote/goober/pull/333 it would make 10B.

**Before:**

```
1173 B: goober.js.gz
1065 B: goober.js.br
1181 B: goober.modern.js.gz
1074 B: goober.modern.js.br
1181 B: goober.esm.js.gz
1074 B: goober.esm.js.br
1241 B: goober.umd.js.gz
1120 B: goober.umd.js.br
```

**Now:**

```
1171 B: goober.js.gz
1061 B: goober.js.br
1179 B: goober.modern.js.gz
1070 B: goober.modern.js.br
1179 B: goober.esm.js.gz
1070 B: goober.esm.js.br
1238 B: goober.umd.js.gz
1114 B: goober.umd.js.br
```

Difference: **-2B**
Difference together with https://github.com/cristianbote/goober/pull/333: **-10B**