### PR TITLE
Fix forwardProps type

### DIFF
--- a/goober.d.ts
+++ b/goober.d.ts
@@ -46,9 +46,7 @@ declare namespace goober {
         (props: any, ref: any): any;
     };
 
-    type ForwardPropsFunction = {
-        (props: object): undefined;
-    };
+    type ForwardPropsFunction = (props: object) => void;
 
     const styled: StyledFunction & BabelPluginTransformGooberStyledFunction;
     function setup<T>(


### PR DESCRIPTION
The type doesn't seem correct, the docs: https://goober.js.org/api/setup. Noticed, while I was working on https://github.com/mui-org/material-ui/pull/27776.