### PR TITLE
Unique class per style call

### DIFF
--- a/src/__tests__/css.test.js
+++ b/src/__tests__/css.test.js
@@ -31,14 +31,28 @@ describe('css', () => {
 
         expect(compile).toBeCalledWith(['base', ''], [1], undefined);
         expect(getSheet).toBeCalled();
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined, undefined);
+        expect(hash).toBeCalledWith(
+            'compile()',
+            'getSheet()',
+            undefined,
+            undefined,
+            undefined,
+            undefined
+        );
         expect(out).toEqual('hash()');
     });
 
     it('args: object', () => {
         const out = css({ foo: 1 });
 
-        expect(hash).toBeCalledWith({ foo: 1 }, 'getSheet()', undefined, undefined, undefined);
+        expect(hash).toBeCalledWith(
+            { foo: 1 },
+            'getSheet()',
+            undefined,
+            undefined,
+            undefined,
+            undefined
+        );
         expect(compile).not.toBeCalled();
         expect(getSheet).toBeCalled();
         expect(out).toEqual('hash()');
@@ -57,6 +71,7 @@ describe('css', () => {
             'getSheet()',
             undefined,
             undefined,
+            undefined,
             undefined
         );
         expect(compile).not.toBeCalled();
@@ -68,7 +83,14 @@ describe('css', () => {
         const incoming = { foo: 'foo' };
         const out = css.call({ p: incoming }, (props) => ({ foo: props.foo }));
 
-        expect(hash).toBeCalledWith(incoming, 'getSheet()', undefined, undefined, undefined);
+        expect(hash).toBeCalledWith(
+            incoming,
+            'getSheet()',
+            undefined,
+            undefined,
+            undefined,
+            undefined
+        );
         expect(compile).not.toBeCalled();
         expect(getSheet).toBeCalled();
         expect(out).toEqual('hash()');
@@ -78,13 +100,15 @@ describe('css', () => {
         const target = '';
         const p = {};
         const g = true;
+        const c = 5;
         const out = css.bind({
             target,
             p,
-            g
+            g,
+            c
         })`foo: 1`;
 
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', true, undefined, undefined);
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', true, undefined, undefined, 5);
         expect(compile).toBeCalledWith(['foo: 1'], [], p);
         expect(getSheet).toBeCalledWith(target);
         expect(out).toEqual('hash()');
@@ -98,7 +122,7 @@ describe('glob', () => {
 
     it('args: g', () => {
         glob`a:b`;
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', 1, undefined, undefined);
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', 1, undefined, undefined, undefined);
     });
 });
 
@@ -109,6 +133,6 @@ describe('keyframes', () => {
 
     it('args: k', () => {
         keyframes`a:b`;
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined, 1);
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined, 1, undefined);
     });
 });

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -24,6 +24,9 @@ describe('integrations', () => {
             }
         `;
 
+        const PlainButton = styled('button')``;
+        const AnotherPlainButton = styled('button')``;
+
         const BoxWithColor = styled('div')`
             color: ${(props) => props.color};
         `;
@@ -82,6 +85,8 @@ describe('integrations', () => {
                     <SpanWrapper>
                         <Span />
                     </SpanWrapper>
+                    <PlainButton />
+                    <AnotherPlainButton />
                     <BoxWithColor color={'red'} />
                     <BoxWithColorFn color={'red'} />
                     <BoxWithThemeColor />
@@ -98,6 +103,31 @@ describe('integrations', () => {
             target
         );
 
+        expect(target.innerHTML).toEqual(
+            [
+                '<div>',
+                '<span class="go3865451590"></span>',
+                '<div class="go3865451590"></div>',
+                '<div class="go3682718143">',
+                '<span class="go3865451590"></span>',
+                '</div>',
+                '<button class="go1161"></button>',
+                '<button class="go1162"></button>',
+                '<div color="red" class="go3863554002"></div>',
+                '<div color="red" class="go3863554003"></div>',
+                '<div class="go1209684397"></div>',
+                '<div class="go1209684398"></div>',
+                '<div theme="[object Object]" class="go1749251122"></div>',
+                '<div theme="[object Object]" class="go2479975434"></div>',
+                '<span class="go2869839072"></span>',
+                '<div isactive="true" class="go3632499960"></div>',
+                '<div class="go98630897"></div>',
+                '<div class="go3838708239"></div>',
+                '<div class="go1127809067"></div>',
+                '</div>'
+            ].join('')
+        );
+
         expect(extractCss()).toMatchInlineSnapshot(
             [
                 '"',
@@ -105,15 +135,19 @@ describe('integrations', () => {
                 '@keyframes go384228713{0%{opacity:0;}99%{opacity:1;color:dodgerblue;}}',
                 '.go1127809067{opacity:0;background:cyan;}',
                 '.go3865451590{color:red;}',
-                '.go3991234422{color:cyan;}',
-                '.go3991234422 .go3865451590{border:1px solid red;}',
-                '.go1925576363{color:blue;}',
-                '.go3206651468{color:green;}',
-                '.go4276997079{color:orange;}',
-                '.go2069586824{opacity:0;animation:go384228713 500ms ease-in-out;}',
-                '.go631307347{foo:1;color:red;baz:0;}',
-                '.go3865943372{opacity:0;}',
-                '.go1162430001{opacity:0;baz:0;}',
+                '.go3682718143{color:cyan;}',
+                '.go3682718143 ',
+                '.go3865451590{border:1px solid red;}',
+                '.go3863554002{color:red;}',
+                '.go3863554003{color:red;}',
+                '.go1209684397{color:blue;}',
+                '.go1209684398{color:blue;}',
+                '.go1749251122{color:green;}',
+                '.go2479975434{color:orange;}',
+                '.go2869839072{opacity:0;animation:go384228713 500ms ease-in-out;}',
+                '.go3632499960{foo:1;color:red;baz:0;}',
+                '.go98630897{opacity:0;}',
+                '.go3838708239{opacity:0;baz:0;}',
                 '"'
             ].join('')
         );
@@ -162,10 +196,10 @@ describe('integrations', () => {
         expect(target.innerHTML).toEqual(
             [
                 '<div>',
-                '<div class="go103173764"></div>',
-                '<div class="go103194166"></div>',
-                '<span class="go2081835032"></span>',
-                '<button class="go1969245729 go1824201605"></button>',
+                '<div class="go208584043"></div>',
+                '<div class="go416704845"></div>',
+                '<span class="go2480855007"></span>',
+                '<button class="go713643136 go2882251333"></button>',
                 '</div>'
             ].join('')
         );
@@ -173,11 +207,11 @@ describe('integrations', () => {
         expect(extractCss()).toMatchInlineSnapshot(
             [
                 '"',
-                '.go1969245729{color:white;padding:0em;margin:1em;}',
-                '.go103173764{color:white;padding:0em;}',
-                '.go103194166{color:white;padding:2em;}',
-                '.go2081835032{color:white;padding:3em;margin:1em;}',
-                '.go1824201605{background:dodgerblue;}',
+                '.go713643136{color:white;padding:0em;margin:1em;}',
+                '.go208584043{color:white;padding:0em;}',
+                '.go416704845{color:white;padding:2em;}',
+                '.go2480855007{color:white;padding:3em;margin:1em;}',
+                '.go2882251333{background:dodgerblue;}',
                 '"'
             ].join('')
         );
@@ -216,20 +250,20 @@ describe('integrations', () => {
         expect(target.innerHTML).toEqual(
             [
                 '<div>',
-                '<div class="go103173764"></div>',
-                '<div class="go103194166"></div>',
-                '<span class="go2081835032"></span>',
+                '<div class="go208584045"></div>',
+                '<div class="go416704847"></div>',
+                '<span class="go2480855009"></span>',
                 '</div>'
             ].join(''),
-            `"<div><div class=\\"go103173764\\"></div><div class=\\"go103194166\\"></div><span class=\\"go2081835032\\"></span></div>"`
+            `"<div><div class=\\"go208584043\\"></div><div class=\\"go416704845\\"></div><span class=\\"go2480855007\\"></span></div>"`
         );
 
         expect(extractCss()).toMatchInlineSnapshot(
             [
                 '"',
-                '.go103173764{color:white;padding:0em;}',
-                '.go103194166{color:white;padding:2em;}',
-                '.go2081835032{color:white;padding:3em;margin:1em;}',
+                '.go208584045{color:white;padding:0em;}',
+                '.go416704847{color:white;padding:2em;}',
+                '.go2480855009{color:white;padding:3em;margin:1em;}',
                 '"'
             ].join('')
         );

--- a/src/__tests__/styled.test.js
+++ b/src/__tests__/styled.test.js
@@ -45,7 +45,7 @@ describe('styled', () => {
             bar: 1,
             className: 'go'
         });
-        expect(extractCss()).toEqual('.go3183460609{color:peachpuff;}');
+        expect(extractCss()).toEqual('.go3701941655{color:peachpuff;}');
     });
 
     it('concat className if present in props', () => {
@@ -66,7 +66,7 @@ describe('styled', () => {
             className: 'go',
             color: 'red'
         });
-        expect(extractCss()).toEqual('.go3433634237{color:red;}');
+        expect(extractCss()).toEqual('.go3199674309{color:red;}');
     });
 
     it('change tag via "as" prop', () => {
@@ -154,6 +154,23 @@ describe('styled', () => {
         let vnode = Tag({ draw: true });
 
         expect(vnode).toMatchVNode('tag', { className: 'go', draw: true });
-        expect(extractCss()).toEqual('.go2986228274{color:yellow;}');
+        expect(extractCss()).toEqual('.go2606564840{color:yellow;}');
+    });
+
+    it('creates unique className per call', () => {
+        const Tag = styled('tag')`
+            color: red;
+        `;
+        const AnotherTag = styled('tag')`
+            color: red;
+        `;
+
+        // Simulate a render
+        let vnode1 = Tag();
+        let vnode2 = AnotherTag();
+
+        expect(vnode1).toMatchVNode('tag', { className: 'go' });
+        expect(vnode2).toMatchVNode('tag', { className: 'go' });
+        expect(extractCss()).toEqual('.go3671897309{color:red;}.go3671897310{color:red;}');
     });
 });

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -32,13 +32,13 @@ let stringify = (data) => {
  * @param {Boolean} keyframes Keyframes mode. The input is the keyframes body that needs to be wrapped.
  * @returns {String}
  */
-export let hash = (compiled, sheet, global, append, keyframes) => {
+export let hash = (compiled, sheet, global, append, keyframes, counter) => {
     // Get a string representation of the object or the value that is called 'compiled'
     let stringifiedCompiled = stringify(compiled);
+    let key = stringifiedCompiled + (counter || '');
 
     // Retrieve the className from cache or hash it in place
-    let className =
-        cache[stringifiedCompiled] || (cache[stringifiedCompiled] = toHash(stringifiedCompiled));
+    let className = cache[key] || (cache[key] = toHash(key));
 
     // If there's no entry for the current className
     if (!cache[className]) {

--- a/src/css.js
+++ b/src/css.js
@@ -21,7 +21,8 @@ function css(val) {
         getSheet(ctx.target),
         ctx.g,
         ctx.o,
-        ctx.k
+        ctx.k,
+        ctx.c
     );
 }
 

--- a/src/styled.js
+++ b/src/styled.js
@@ -17,8 +17,11 @@ function setup(pragma, prefix, theme, forwardProps) {
  * @param {string} tag
  * @param {function} forwardRef
  */
+
+let counter = 0;
+
 function styled(tag, forwardRef) {
-    let _ctx = this || {};
+    let _ctx = this || { c: counter++ };
 
     return function wrapper() {
         let _args = arguments;


### PR DESCRIPTION
Fixes #397

@cristianbote Look for PlainButton in test cases to see how each styled component now generates a new className.  Multiple instances of PlainButton still use the same className as expected.