### PR TITLE
Assign id to styled components

### DIFF
--- a/src/__tests__/css.test.js
+++ b/src/__tests__/css.test.js
@@ -31,14 +31,28 @@ describe('css', () => {
 
         expect(compile).toBeCalledWith(['base', ''], [1], undefined);
         expect(getSheet).toBeCalled();
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined, undefined);
+        expect(hash).toBeCalledWith(
+            'compile()',
+            'getSheet()',
+            undefined,
+            undefined,
+            undefined,
+            undefined
+        );
         expect(out).toEqual('hash()');
     });
 
     it('args: object', () => {
         const out = css({ foo: 1 });
 
-        expect(hash).toBeCalledWith({ foo: 1 }, 'getSheet()', undefined, undefined, undefined);
+        expect(hash).toBeCalledWith(
+            { foo: 1 },
+            'getSheet()',
+            undefined,
+            undefined,
+            undefined,
+            undefined
+        );
         expect(compile).not.toBeCalled();
         expect(getSheet).toBeCalled();
         expect(out).toEqual('hash()');
@@ -57,6 +71,7 @@ describe('css', () => {
             'getSheet()',
             undefined,
             undefined,
+            undefined,
             undefined
         );
         expect(compile).not.toBeCalled();
@@ -68,7 +83,14 @@ describe('css', () => {
         const incoming = { foo: 'foo' };
         const out = css.call({ p: incoming }, (props) => ({ foo: props.foo }));
 
-        expect(hash).toBeCalledWith(incoming, 'getSheet()', undefined, undefined, undefined);
+        expect(hash).toBeCalledWith(
+            incoming,
+            'getSheet()',
+            undefined,
+            undefined,
+            undefined,
+            undefined
+        );
         expect(compile).not.toBeCalled();
         expect(getSheet).toBeCalled();
         expect(out).toEqual('hash()');
@@ -84,7 +106,14 @@ describe('css', () => {
             g
         })`foo: 1`;
 
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', true, undefined, undefined);
+        expect(hash).toBeCalledWith(
+            'compile()',
+            'getSheet()',
+            true,
+            undefined,
+            undefined,
+            undefined
+        );
         expect(compile).toBeCalledWith(['foo: 1'], [], p);
         expect(getSheet).toBeCalledWith(target);
         expect(out).toEqual('hash()');
@@ -98,7 +127,7 @@ describe('glob', () => {
 
     it('args: g', () => {
         glob`a:b`;
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', 1, undefined, undefined);
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', 1, undefined, undefined, undefined);
     });
 });
 
@@ -109,6 +138,6 @@ describe('keyframes', () => {
 
     it('args: k', () => {
         keyframes`a:b`;
-        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined, 1);
+        expect(hash).toBeCalledWith('compile()', 'getSheet()', undefined, undefined, 1, undefined);
     });
 });

--- a/src/__tests__/integrations.test.js
+++ b/src/__tests__/integrations.test.js
@@ -24,6 +24,9 @@ describe('integrations', () => {
             }
         `;
 
+        const Button = styled('button', null, 'id1')``;
+        const AnotherButton = styled('button', null, 'id2')``;
+
         const BoxWithColor = styled('div')`
             color: ${(props) => props.color};
         `;
@@ -82,6 +85,8 @@ describe('integrations', () => {
                     <SpanWrapper>
                         <Span />
                     </SpanWrapper>
+                    <Button />
+                    <AnotherButton />
                     <BoxWithColor color={'red'} />
                     <BoxWithColorFn color={'red'} />
                     <BoxWithThemeColor />
@@ -96,6 +101,31 @@ describe('integrations', () => {
                 </div>
             </ThemeContext.Provider>,
             target
+        );
+
+        expect(target.innerHTML).toEqual(
+            [
+                '<div>',
+                '<span class="go3865451590"></span>',
+                '<div class="go3865451590"></div>',
+                '<div class="go3991234422">',
+                '<span class="go3865451590"></span>',
+                '</div>',
+                '<button class="go12414565"></button>',
+                '<button class="go12414566"></button>',
+                '<div color="red" class="go3865451590"></div>',
+                '<div color="red" class="go3865451590"></div>',
+                '<div class="go1925576363"></div>',
+                '<div class="go1925576363"></div>',
+                '<div theme="[object Object]" class="go3206651468"></div>',
+                '<div theme="[object Object]" class="go4276997079"></div>',
+                '<span class="go2069586824"></span>',
+                '<div isactive="true" class="go631307347"></div>',
+                '<div class="go3865943372"></div>',
+                '<div class="go1162430001"></div>',
+                '<div class="go1127809067"></div>',
+                '</div>'
+            ].join('')
         );
 
         expect(extractCss()).toMatchInlineSnapshot(
@@ -220,8 +250,7 @@ describe('integrations', () => {
                 '<div class="go103194166"></div>',
                 '<span class="go2081835032"></span>',
                 '</div>'
-            ].join(''),
-            `"<div><div class=\\"go103173764\\"></div><div class=\\"go103194166\\"></div><span class=\\"go2081835032\\"></span></div>"`
+            ].join('')
         );
 
         expect(extractCss()).toMatchInlineSnapshot(

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -32,13 +32,13 @@ let stringify = (data) => {
  * @param {Boolean} keyframes Keyframes mode. The input is the keyframes body that needs to be wrapped.
  * @returns {String}
  */
-export let hash = (compiled, sheet, global, append, keyframes) => {
+export let hash = (compiled, sheet, global, append, keyframes, id) => {
     // Get a string representation of the object or the value that is called 'compiled'
     let stringifiedCompiled = stringify(compiled);
+    let key = stringifiedCompiled + (id || '');
 
     // Retrieve the className from cache or hash it in place
-    let className =
-        cache[stringifiedCompiled] || (cache[stringifiedCompiled] = toHash(stringifiedCompiled));
+    let className = cache[key] || (cache[key] = toHash(key));
 
     // If there's no entry for the current className
     if (!cache[className]) {

--- a/src/css.js
+++ b/src/css.js
@@ -21,7 +21,8 @@ function css(val) {
         getSheet(ctx.target),
         ctx.g,
         ctx.o,
-        ctx.k
+        ctx.k,
+        ctx.i
     );
 }
 

--- a/src/styled.js
+++ b/src/styled.js
@@ -16,8 +16,9 @@ function setup(pragma, prefix, theme, forwardProps) {
  * styled function
  * @param {string} tag
  * @param {function} forwardRef
+ * @param {string} id
  */
-function styled(tag, forwardRef) {
+function styled(tag, forwardRef, id) {
     let _ctx = this || {};
 
     return function wrapper() {
@@ -37,6 +38,8 @@ function styled(tag, forwardRef) {
             // similar to goober. This is the append/prepend flag
             // The _empty_ space compresses better than `\s`
             _ctx.o = / *go\d+/.test(_previousClassName);
+
+            _ctx.i = id;
 
             _props.className =
                 // Define the new className


### PR DESCRIPTION
@cristianbote I believe this approach will work without causing a hydration issue.
This approach let's the user assign a unique id to their styled components which is used by the toHash function to generate different classNames per styled component.

```javascript
const Button = styled('button', null, 'id1')``;
const AnotherButton = styled('button', null, 'id2')``;
```

Fixes #397