### PR TITLE
adds `defaultProps` to `StyledVNode` type

### DIFF
--- a/goober.d.ts
+++ b/goober.d.ts
@@ -70,6 +70,7 @@ declare namespace goober {
     ): string;
 
     type StyledVNode<T> = ((props: T, ...args: any[]) => any) & {
+        defaultProps?: T;
         displayName?: string;
     };
 


### PR DESCRIPTION
Closes #409 

Adds support for the [`defaultProps`](https://reactjs.org/docs/typechecking-with-proptypes.html#default-prop-values) property, adding it to the `StyledVNode` type.