### PR TITLE
Rewrote astish to recursion instead of while loop and shave some bytes

### DIFF
--- a/src/core/__tests__/astish.test.js
+++ b/src/core/__tests__/astish.test.js
@@ -3,9 +3,12 @@ import { astish } from '../astish';
 describe('astish', () => {
     it('regular', () => {
         expect(
-            astish(`
+            astish(
+                `
             prop: value;
-        `)
+        `,
+                [{}]
+            )
         ).toEqual({
             prop: 'value'
         });
@@ -13,7 +16,8 @@ describe('astish', () => {
 
     it('nested', () => {
         expect(
-            astish(`
+            astish(
+                `
             prop: value;
             @keyframes foo {
                 0% {
@@ -34,7 +38,9 @@ describe('astish', () => {
             &:hover {
                 -webkit-touch: none;
             }
-        `)
+        `,
+                [{}]
+            )
         ).toEqual({
             prop: 'value',
             opacity: '0',
@@ -61,7 +67,8 @@ describe('astish', () => {
 
     it('merging', () => {
         expect(
-            astish(`
+            astish(
+                `
             .c {
                 font-size:24px;
             }
@@ -69,7 +76,9 @@ describe('astish', () => {
             .c {
                 color:red;
             }
-        `)
+        `,
+                [{}]
+            )
         ).toEqual({
             '.c': {
                 'font-size': '24px',
@@ -80,7 +89,8 @@ describe('astish', () => {
 
     it('regression', () => {
         expect(
-            astish(`
+            astish(
+                `
             &.g0ssss {
                 aa: foo;
                 box-shadow: 0 1px rgba(0, 2, 33, 4) inset;
@@ -104,7 +114,9 @@ describe('astish', () => {
             .b  {
                 color: blue;
             }
-        `)
+        `,
+                [{}]
+            )
         ).toEqual({
             '&.g0ssss': {
                 aa: 'foo',
@@ -135,7 +147,8 @@ describe('astish', () => {
 
     it('should strip comments', () => {
         expect(
-            astish(`
+            astish(
+                `
                 color: red;
                 /*
                     some comment
@@ -148,7 +161,9 @@ describe('astish', () => {
                 font-size: xx-large; /* inline comment */
                 /* foo: bar */
                 font-weight: bold;
-            `)
+            `,
+                [{}]
+            )
         ).toEqual({
             color: 'red',
             transform: 'translate3d(0, 0, 0)',
@@ -162,11 +177,14 @@ describe('astish', () => {
     // https://www.w3.org/TR/CSS22/syndata.html#value-def-identifier
     it('should not mangle valid css identifiers', () => {
         expect(
-            astish(`
+            astish(
+                `
                 :root {
                   --azAZ-_中文09: 0;
                 }
-            `)
+            `,
+                [{}]
+            )
         ).toEqual({
             ':root': {
                 '--azAZ-_中文09': '0'
@@ -176,10 +194,13 @@ describe('astish', () => {
 
     it('should parse multiline background declaration', () => {
         expect(
-            astish(`
+            astish(
+                `
                 background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="white"><path d="M7.5 36.7h58.4v10.6H7.5V36.7zm0-15.9h58.4v10.6H7.5V20.8zm0 31.9h58.4v10.6H7.5V52.7zm0 15.9h58.4v10.6H7.5V68.6zm63.8-15.9l10.6 15.9 10.6-15.9H71.3zm21.2-5.4L81.9 31.4 71.3 47.3h21.2z"/></svg>')
                     center/contain;
-            `)
+            `,
+                [{}]
+            )
         ).toEqual({
             background: `url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="white"><path d="M7.5 36.7h58.4v10.6H7.5V36.7zm0-15.9h58.4v10.6H7.5V20.8zm0 31.9h58.4v10.6H7.5V52.7zm0 15.9h58.4v10.6H7.5V68.6zm63.8-15.9l10.6 15.9 10.6-15.9H71.3zm21.2-5.4L81.9 31.4 71.3 47.3h21.2z"/></svg>')center/contain`
         });
@@ -188,7 +209,8 @@ describe('astish', () => {
     it('should handle inline @media block', () => {
         expect(
             astish(
-                `h1 { font-size: 1rem; } @media only screen and (min-width: 850px) { h1 { font-size: 2rem; } }`
+                `h1 { font-size: 1rem; } @media only screen and (min-width: 850px) { h1 { font-size: 2rem; } }`,
+                [{}]
             )
         ).toEqual({
             h1: {

--- a/src/core/__tests__/hash.test.js
+++ b/src/core/__tests__/hash.test.js
@@ -41,7 +41,7 @@ describe('hash', () => {
 
         expect(toHash).toBeCalledWith('compiled');
         expect(update).toBeCalledWith('parse()', 'target', undefined);
-        expect(astish).toBeCalledWith('compiled');
+        expect(astish).toBeCalledWith('compiled', [{}]);
         expect(parse).toBeCalledWith('astish()', '.toHash()');
 
         expect(res).toEqual('toHash()');

--- a/src/core/astish.js
+++ b/src/core/astish.js
@@ -6,20 +6,20 @@ let ruleClean = /\/\*[^]*?\*\/|\s\s+|\n/g;
  * @param {String} val
  * @returns {Object}
  */
-export let astish = (val) => {
-    let tree = [{}];
-    let block;
-
-    while ((block = newRule.exec(val.replace(ruleClean, '')))) {
-        // Remove the current entry
-        if (block[4]) {
-            tree.shift();
-        } else if (block[3]) {
-            tree.unshift((tree[0][block[3]] = tree[0][block[3]] || {}));
-        } else {
-            tree[0][block[1]] = block[2];
-        }
+export let astish = (val, tree) => {
+    let block = newRule.exec(val.replace(ruleClean, ''));
+    if (!block) {
+        return tree[0];
     }
 
-    return tree[0];
+    // Remove the current entry
+    if (block[4]) {
+        tree.shift();
+    } else if (block[3]) {
+        tree.unshift((tree[0][block[3]] = tree[0][block[3]] || {}));
+    } else {
+        tree[0][block[1]] = block[2];
+    }
+
+    return astish(val, tree);
 };

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -43,7 +43,7 @@ export let hash = (compiled, sheet, global, append, keyframes) => {
     // If there's no entry for the current className
     if (!cache[className]) {
         // Build the _ast_-ish structure if needed
-        let ast = stringifiedCompiled !== compiled ? compiled : astish(compiled);
+        let ast = stringifiedCompiled !== compiled ? compiled : astish(compiled, [{}]);
 
         // Parse it
         cache[className] = parse(


### PR DESCRIPTION
Rewrote `astish` function to recursion instead of while loop and shave some bytes

<h3>Size comparison</h3>
<b>Before:</b>

```
Wrote 1183 B: goober.cjs.gz
       1079 B: goober.cjs.br
Wrote 1188 B: goober.esm.js.gz
       1085 B: goober.esm.js.br
Wrote 1257 B: goober.umd.js.gz
       1137 B: goober.umd.js.br
Wrote 1188 B: goober.modern.js.gz
       1085 B: goober.modern.js.br
```

<b>After:</b>
```
Wrote 1185 B: goober.cjs.gz
       1078 B: goober.cjs.br
Wrote 1186 B: goober.esm.js.gz
       1090 B: goober.esm.js.br
Wrote 1252 B: goober.umd.js.gz
       1134 B: goober.umd.js.br
Wrote 1186 B: goober.modern.js.gz
       1090 B: goober.modern.js.br
```