### PR TITLE
skip parsing and formatting custom CSS properties

### DIFF
--- a/src/core/__tests__/parse.test.js
+++ b/src/core/__tests__/parse.test.js
@@ -299,4 +299,29 @@ describe('parse', () => {
             )
         ).toEqual('div{opacity:0;}');
     });
+
+    it('does not transform the case of custom CSS variables', () => {
+        expect(
+            parse({
+                '--cP': 'red'
+            })
+        ).toEqual('--cP:red;');
+        expect(
+            parse({
+                '--c-P': 'red'
+            })
+        ).toEqual('--c-P:red;');
+        expect(
+            parse({
+                '--cp': 'red'
+            })
+        ).toEqual('--cp:red;');
+        expect(
+            parse({
+                ':root': {
+                    '--cP': 'red'
+                }
+            })
+        ).toEqual(':root{--cP:red;}');
+    });
 });

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -43,7 +43,8 @@ export let parse = (obj, selector) => {
                       })
                     : key
             );
-        } else if (val != undefined) {
+            // Parse and standardize all but custom CSS properties
+        } else if (val != undefined && !key.startsWith('--')) {
             // If this isn't an empty rule
             key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
             // Push the line for this property

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -45,7 +45,7 @@ export let parse = (obj, selector) => {
             );
         } else if (val != undefined) {
             // Convert all but CSS variables
-            key = key.startsWith('--') ? key : key.replace(/[A-Z]/g, '-$&').toLowerCase();
+            key = /^--/.test(key) ? key : key.replace(/[A-Z]/g, '-$&').toLowerCase();
             // Push the line for this property
             current += parse.p
                 ? // We have a prefixer and we need to run this through that

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -43,10 +43,9 @@ export let parse = (obj, selector) => {
                       })
                     : key
             );
-            // Parse and standardize all but custom CSS properties
-        } else if (val != undefined && !key.startsWith('--')) {
-            // If this isn't an empty rule
-            key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
+        } else if (val != undefined) {
+            // Convert all but CSS variables
+            key = key.startsWith('--') ? key : key.replace(/[A-Z]/g, '-$&').toLowerCase();
             // Push the line for this property
             current += parse.p
                 ? // We have a prefixer and we need to run this through that


### PR DESCRIPTION
~*Untested*~

Closes #423 

Skips formatting custom CSS properties using a lax check that a property's key does not begin with `--`.