### PR TITLE
[FIX] `null` checking for conditional styling not worked

### DIFF
--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -11,7 +11,7 @@ export let parse = (obj, selector) => {
 
     for (let key in obj) {
         let val = obj[key];
-        if (/^(null|undefined)$/.test(val)) {
+        if (!/^(null|undefined)$/.test(val)) {
             if (key[0] == '@') {
                 // If these are the `@` rule
                 if (key[1] == 'i') {

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -11,7 +11,7 @@ export let parse = (obj, selector) => {
 
     for (let key in obj) {
         let val = obj[key];
-        if (/^(null|undefined)$/.test(val)) {
+        if (val != undefined) {
             if (key[0] == '@') {
                 // If these are the `@` rule
                 if (key[1] == 'i') {

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -11,7 +11,7 @@ export let parse = (obj, selector) => {
 
     for (let key in obj) {
         let val = obj[key];
-        if (val != undefined) {
+        if (/^(null|undefined)$/.test(val)) {
             if (key[0] == '@') {
                 // If these are the `@` rule
                 if (key[1] == 'i') {

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -11,47 +11,48 @@ export let parse = (obj, selector) => {
 
     for (let key in obj) {
         let val = obj[key];
+        if (/^(null|undefined)$/.test(val)) {
+            if (key[0] == '@') {
+                // If these are the `@` rule
+                if (key[1] == 'i') {
+                    // Handling the `@import`
+                    outer = key + ' ' + val + ';';
+                } else if (key[1] == 'f') {
+                    // Handling the `@font-face` where the
+                    // block doesn't need the brackets wrapped
+                    blocks += parse(val, key);
+                } else {
+                    // Regular at rule block
+                    blocks += key + '{' + parse(val, key[1] == 'k' ? '' : selector) + '}';
+                }
+            } else if (typeof val == 'object') {
+                // Call the parse for this block
+                blocks += parse(
+                    val,
+                    selector
+                        ? // Go over the selector and replace the matching multiple selectors if any
+                          selector.replace(/([^,])+/g, (sel) => {
+                              // Return the current selector with the key matching multiple selectors if any
+                              return key.replace(/(^:.*)|([^,])+/g, (k) => {
+                                  // If the current `k`(key) has a nested selector replace it
+                                  if (/&/.test(k)) return k.replace(/&/g, sel);
 
-        if (key[0] == '@') {
-            // If these are the `@` rule
-            if (key[1] == 'i') {
-                // Handling the `@import`
-                outer = key + ' ' + val + ';';
-            } else if (key[1] == 'f') {
-                // Handling the `@font-face` where the
-                // block doesn't need the brackets wrapped
-                blocks += parse(val, key);
+                                  // If there's a current selector concat it
+                                  return sel ? sel + ' ' + k : k;
+                              });
+                          })
+                        : key
+                );
             } else {
-                // Regular at rule block
-                blocks += key + '{' + parse(val, key[1] == 'k' ? '' : selector) + '}';
+                // If this isn't an empty rule
+                key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
+                // Push the line for this property
+                current += parse.p
+                    ? // We have a prefixer and we need to run this through that
+                      parse.p(key, val)
+                    : // Nope no prefixer just append it
+                      key + ':' + val + ';';
             }
-        } else if (typeof val == 'object') {
-            // Call the parse for this block
-            blocks += parse(
-                val,
-                selector
-                    ? // Go over the selector and replace the matching multiple selectors if any
-                      selector.replace(/([^,])+/g, (sel) => {
-                          // Return the current selector with the key matching multiple selectors if any
-                          return key.replace(/(^:.*)|([^,])+/g, (k) => {
-                              // If the current `k`(key) has a nested selector replace it
-                              if (/&/.test(k)) return k.replace(/&/g, sel);
-
-                              // If there's a current selector concat it
-                              return sel ? sel + ' ' + k : k;
-                          });
-                      })
-                    : key
-            );
-        } else if (val != undefined) {
-            // If this isn't an empty rule
-            key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
-            // Push the line for this property
-            current += parse.p
-                ? // We have a prefixer and we need to run this through that
-                  parse.p(key, val)
-                : // Nope no prefixer just append it
-                  key + ':' + val + ';';
         }
     }
 


### PR DESCRIPTION
The following case(red line) not worked when used with template literals. So fixed it. conditional styling feature is added by me. very sorry for this mistake.
```diff
const Btn = styled("button")(
  (props) => `
  border-radius: ${props.rounded};
`
);

<Btn rounded="2px" />; // => `border-radius: 2;`

let isRounded = false
- <Btn rounded={isRounded ? "4px" : null} />; // => `border-radius: null;`

<Btn>; // => `border-radius: undefined;`
```
