### PR TITLE
Fix #376

### DIFF
--- a/src/core/__tests__/hash.test.js
+++ b/src/core/__tests__/hash.test.js
@@ -40,7 +40,7 @@ describe('hash', () => {
         const res = hash('compiled', 'target');
 
         expect(toHash).toBeCalledWith('compiled');
-        expect(update).toBeCalledWith('parse()', 'target', undefined);
+        expect(update).toBeCalledWith('parse()', 'target', undefined, null);
         expect(astish).toBeCalledWith('compiled');
         expect(parse).toBeCalledWith('astish()', '.toHash()');
 
@@ -53,7 +53,7 @@ describe('hash', () => {
         expect(toHash).not.toBeCalled();
         expect(astish).not.toBeCalled();
         expect(parse).not.toBeCalled();
-        expect(update).toBeCalledWith('parse()', 'target', undefined);
+        expect(update).toBeCalledWith('parse()', 'target', undefined, null);
 
         expect(res).toEqual('toHash()');
     });
@@ -64,7 +64,18 @@ describe('hash', () => {
         expect(toHash).toBeCalledWith('global');
         expect(astish).not.toBeCalled();
         expect(parse).not.toBeCalled();
-        expect(update).toBeCalledWith('parse()', 'target', undefined);
+        expect(update).toBeCalledWith('parse()', 'target', undefined, null);
+
+        expect(res).toEqual('toHash()');
+    });
+
+    it('regression: global-style-replace', () => {
+        const res = hash('global', 'target', true);
+
+        expect(toHash).not.toBeCalled();
+        expect(astish).not.toBeCalled();
+        expect(parse).not.toBeCalled();
+        expect(update).toBeCalledWith('parse()', 'target', undefined, 'parse()');
 
         expect(res).toEqual('toHash()');
     });
@@ -75,7 +86,7 @@ describe('hash', () => {
         expect(toHash).toBeCalledWith('keyframes');
         expect(astish).not.toBeCalled();
         expect(parse).not.toBeCalled();
-        expect(update).toBeCalledWith('parse()', 'target', undefined);
+        expect(update).toBeCalledWith('parse()', 'target', undefined, null);
 
         expect(res).toEqual('toHash()');
     });
@@ -89,7 +100,7 @@ describe('hash', () => {
         expect(toHash).toBeCalledWith('baz1');
         expect(astish).not.toBeCalled();
         expect(parse).toBeCalledWith({ baz: 1 }, '.' + className);
-        expect(update).toBeCalledWith('parse()', 'target', undefined);
+        expect(update).toBeCalledWith('parse()', 'target', undefined, null);
 
         expect(res).toEqual(className);
     });

--- a/src/core/__tests__/update.test.js
+++ b/src/core/__tests__/update.test.js
@@ -48,4 +48,17 @@ describe('update', () => {
         update('start', getSheet(), true);
         expect(extractCss()).toEqual('startend');
     });
+
+    it('regression: global style replacement', () => {
+        const t = { data: 'html, body { background-color: white; }' };
+
+        update(
+            'html, body { background-color: black; }',
+            t,
+            undefined,
+            'html, body { background-color: white; }'
+        );
+
+        expect(t.data).toEqual('html, body { background-color: black; }');
+    });
 });

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -53,8 +53,14 @@ export let hash = (compiled, sheet, global, append, keyframes) => {
         );
     }
 
+    // If the global flag is set, save the current stringified and compiled CSS to `cache.g`
+    // to allow replacing styles in <style /> instead of appending them.
+    // This is required for using `createGlobalStyles` with themes
+    let cssToReplace = global && cache.g ? cache.g : null;
+    if (global) cache.g = cache[className];
+
     // add or update
-    update(cache[className], sheet, append);
+    update(cache[className], sheet, append, cssToReplace);
 
     // return hash
     return className;

--- a/src/core/update.js
+++ b/src/core/update.js
@@ -15,7 +15,11 @@ export let extractCss = (target) => {
  * @param {String} css
  * @param {Object} sheet
  * @param {Boolean} append
+ * @param {?String} cssToReplace
  */
-export let update = (css, sheet, append) => {
-    sheet.data.indexOf(css) == -1 && (sheet.data = append ? css + sheet.data : sheet.data + css);
+export let update = (css, sheet, append, cssToReplace) => {
+    cssToReplace
+        ? (sheet.data = sheet.data.replace(cssToReplace, css))
+        : sheet.data.indexOf(css) === -1 &&
+          (sheet.data = append ? css + sheet.data : sheet.data + css);
 };


### PR DESCRIPTION
Resolves #376.

@cristianbote This PR would increase the bundle size of goober but only by a few bytes.
```
1242 B: goober.cjs.gz
1133 B: goober.cjs.br
1252 B: goober.modern.js.gz
1149 B: goober.modern.js.br
1252 B: goober.esm.js.gz
1149 B: goober.esm.js.br
1315 B: goober.umd.js.gz
1195 B: goober.umd.js.br
```

Here is a [CodeSandbox demo](https://codesandbox.io/s/theming-preact-goober-rk92xb) where `createGlobalStyles` works correctly with themes.