### PR TITLE
Added note about unsupported `import styled from`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Here we go:
 | `css` prop             | ✅      | ✅                | ✅      |
 | `styled`               | ✅      | ✅                | ✅      |
 | `styled.<tag>`         | ✅ \*2  | ✅                | ✅      |
+| `import styled from `  | 🛑      | ✅                | ✅      |
 | `as`                   | ✅      | ✅                | ✅      |
 | `.withComponent`       | 🛑      | ✅                | ✅      |
 | `.attrs`               | 🛑      | ✅                | 🛑      |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Here we go:
 | `css` prop             | ✅      | ✅                | ✅      |
 | `styled`               | ✅      | ✅                | ✅      |
 | `styled.<tag>`         | ✅ \*2  | ✅                | ✅      |
-| `import styled from `  | 🛑      | ✅                | ✅      |
+| default export  | 🛑      | ✅                | ✅      |
 | `as`                   | ✅      | ✅                | ✅      |
 | `.withComponent`       | 🛑      | ✅                | ✅      |
 | `.attrs`               | 🛑      | ✅                | 🛑      |


### PR DESCRIPTION
Since [in other sections of these docs](https://github.com/cristianbote/goober#ssr-1) we are using `import styled from`, it makes it seem that this is supported by goober, while it's not actually supported. So added it to the table of things that are not supported.