### PR TITLE
Export types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "require": "./dist/goober.cjs",
       "import": "./dist/goober.modern.js",
       "umd": "./dist/goober.umd.js",
-      "types": "./dist/goober.d.ts"
+      "types": "./goober.d.ts"
     },
     "./macro": "./macro/index.js",
     "./global": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     ".": {
       "require": "./dist/goober.cjs",
       "import": "./dist/goober.modern.js",
-      "umd": "./dist/goober.umd.js"
+      "umd": "./dist/goober.umd.js",
+      "types": "./dist/goober.d.ts"
     },
     "./macro": "./macro/index.js",
     "./global": {


### PR DESCRIPTION
PR exports types in package.json file. 

When using new `bundler` option for `moduleResolution` in `tsconfig.json` as part of TypeScript V5, you will receive the following error: 

```
error TS7016: Could not find a declaration file for module 'goober'. '.../node_modules/goober/dist/goober.modern.js' implicitly has an 'any' type.
There are types at '.../node_modules/goober/goober.d.ts', but this result could not be resolved when respecting package.json "exports". The 'goober' library may need to update its package.json or typings.
```