### PR TITLE
fix: don't use `globalThis` when using `this`

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -7,7 +7,7 @@ import { getSheet } from './core/get-sheet';
  * @param {String|Object|Function} val
  */
 function css(val) {
-    let ctx = this || {};
+    let ctx = (this !== globalThis ? this : undefined) || {};
     let _val = val.call ? val(ctx.p) : val;
 
     return hash(

--- a/src/styled.js
+++ b/src/styled.js
@@ -18,7 +18,7 @@ function setup(pragma, prefix, theme, forwardProps) {
  * @param {function} forwardRef
  */
 function styled(tag, forwardRef) {
-    let _ctx = this || {};
+    let _ctx = (this !== globalThis ? this : undefined) || {};
 
     return function wrapper() {
         let _args = arguments;


### PR DESCRIPTION
Without "use strict", `this` will be set to `globalThis` which is typically the window object. If certain properties are set on the window object (e.g. "window.target"), this can cause problems for the `css` and `styled` functions.

Instead, check that `this` has been set to something other than `globalThis` before using it. This ensures that `this` will only have a value if it is explicitly bound, and otherwise will be `undefined`.

Note: I tried to add "use strict"; directives where needed, but couldn't get them to "survive" the build process -- they were removed. This fix seems to work just fine.

Closes https://github.com/cristianbote/goober/issues/545