### PR TITLE
export type in package.json should-forward-prop path

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,14 @@
     "./global": {
       "import": "./global/dist/goober-global.modern.js",
       "require": "./global/dist/goober-global.cjs",
-      "umd": "./global/dist/goober-global.umd.js"
+      "umd": "./global/dist/goober-global.umd.js",
+      "types": "./global/global.d.ts"
     },
     "./prefixer": {
       "import": "./prefixer/dist/goober-autoprefixer.modern.js",
       "require": "./prefixer/dist/goober-autoprefixer.cjs",
-      "umd": "./prefixer/dist/goober-autoprefixer.umd.js"
+      "umd": "./prefixer/dist/goober-autoprefixer.umd.js",
+      "types": "./prefixer/autoprefixer.d.ts"
     },
     "./should-forward-prop": {
       "import": "./should-forward-prop/dist/goober-should-forward-prop.modern.js",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "./should-forward-prop": {
       "import": "./should-forward-prop/dist/goober-should-forward-prop.modern.js",
       "require": "./should-forward-prop/dist/goober-should-forward-prop.cjs",
-      "umd": "./should-forward-prop/dist/goober-should-forward-prop.umd.js"
+      "umd": "./should-forward-prop/dist/goober-should-forward-prop.umd.js",
+      "types": "./should-forward-prop/should-forward-prop.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Defines types in the exports map, so that imports work when leveraging the newer moduleResolution tsconfig values (nodenext, node16, bundler).