### PR TITLE
Explore xxh algo and benchmark

### DIFF
--- a/benchmarks/perf-hash.cjs
+++ b/benchmarks/perf-hash.cjs
@@ -1,31 +1,166 @@
 const Benchmark = require('benchmark');
 
-const str = `abcdefghijklmnopqrstuvwyxz ABCDEFGHIJKLMNOPQRSTUVWYXZ 0123456789`
+const str = `abcdefghijklmnopqrstuvwyxz ABCDEFGHIJKLMNOPQRSTUVWYXZ 0123456789`;
+const getUint32 = (arr, i) =>
+    arr[i] | (arr[(i + 1) | 0] << 8) | (arr[(i + 2) | 0] << 16) | (arr[(i + 3) | 0] << 24);
+const rotl32 = (x, r) => (x << r) | (x >>> (32 - r));
+const encoder = new TextEncoder();
+let bufferLength = 2 * 1024;
+let buffer = new ArrayBuffer(bufferLength);
+let uint8View = new Uint8Array(buffer);
+let int32View = new Int32Array(buffer);
 
-const suite = new Benchmark.Suite("HASH!");
+const suite = new Benchmark.Suite('HASH!');
 suite
-.add('goober original HASH', () => {
-    const c = 'go' + str.split('').reduce((out, s) => (101 * out + s.charCodeAt(0)) >>> 0, 11);
-})
-.add('goober optimized HASH', () => {
-    let i = 0, l = str.length, out = 11;
-    while (i < l) out = (101 * out + str.charCodeAt(i++)) >>> 0
-    const c = 'go' + out;
-})
-.add('twind HASH', () => {
-    let i = str.length - 1, out = 9;
-    while (i >= 0) out = Math.imul(out ^ str.charCodeAt(i--), 0x5f356495);
-    const c = 'go' + ((out ^ (out >>> 9)) >>> 0).toString(36);
-})
-.on('start', function (e) {
-    console.log('\nStarting', e.currentTarget.name);
-})
-.on('error', (e) => console.log(e))
-.on('cycle', function (event) {
-    console.log('▸', String(event.target));
-})
-.on('complete', function () {
-    const fastest = this.filter('fastest').map('name')[0];
-    console.log('\nFastest is: ' + fastest);
-})
-.run();
+    .add('goober original HASH', () => {
+        const c = 'go' + str.split('').reduce((out, s) => (101 * out + s.charCodeAt(0)) >>> 0, 11);
+    })
+    .add('goober optimized HASH', () => {
+        let i = 0,
+            l = str.length,
+            out = 11;
+        while (i < l) out = (101 * out + str.charCodeAt(i++)) >>> 0;
+        const c = 'go' + out;
+    })
+    .add('goober optimized HASH with ASM hints', () => {
+        let i = 0,
+            l = str.length,
+            out = 11;
+        while (i < l) out = ((Math.imul(101, out) + str.charCodeAt(i++)) | 0) >>> 0;
+        const c = 'go' + out;
+    })
+    .add('twind HASH', () => {
+        let i = str.length - 1,
+            out = 9;
+        while (i >= 0) out = Math.imul(out ^ str.charCodeAt(i--), 0x5f356495);
+        const c = 'go' + ((out ^ (out >>> 9)) >>> 0).toString(36);
+    })
+    .add('xxh', () => {
+        if (str.length > bufferLength) {
+            // buffer.resize() is only available in recent browsers, so we re-allocate
+            // a new and views
+            bufferLength = str.length + (4 - (str.length % 4));
+            buffer = new ArrayBuffer(bufferLength);
+
+            uint8View = new Uint8Array(buffer);
+            int32View = new Int32Array(buffer);
+        }
+
+        const length8 = encoder.encodeInto(str, uint8View).written;
+
+        const buf = uint8View;
+
+        const seed = 0;
+        const len = length8 | 0;
+        let i = 0;
+        let h = (((seed + len) | 0) + 0x165667b1) | 0;
+
+        if (len < 16) {
+            for (; ((i + 3) | 0) < len; i = (i + 4) | 0)
+                h = Math.imul(
+                    rotl32((h + Math.imul(getUint32(buf, i), 0xc2b2ae3d)) | 0, 17),
+                    0x27d4eb2f
+                );
+        } else {
+            let v0 = (seed + 0x24234428) | 0;
+            let v1 = (seed + 0x85ebca77) | 0;
+            let v2 = seed;
+            let v3 = (seed - 0x9e3779b1) | 0;
+
+            if (len < 256) {
+                for (; ((i + 15) | 0) < len; i = (i + 16) | 0) {
+                    v0 = Math.imul(
+                        rotl32((v0 + Math.imul(getUint32(buf, (i + 0) | 0), 0x85ebca77)) | 0, 13),
+                        0x9e3779b1
+                    );
+                    v1 = Math.imul(
+                        rotl32((v1 + Math.imul(getUint32(buf, (i + 4) | 0), 0x85ebca77)) | 0, 13),
+                        0x9e3779b1
+                    );
+                    v2 = Math.imul(
+                        rotl32((v2 + Math.imul(getUint32(buf, (i + 8) | 0), 0x85ebca77)) | 0, 13),
+                        0x9e3779b1
+                    );
+                    v3 = Math.imul(
+                        rotl32((v3 + Math.imul(getUint32(buf, (i + 12) | 0), 0x85ebca77)) | 0, 13),
+                        0x9e3779b1
+                    );
+                }
+
+                h =
+                    (((((((rotl32(v0, 1) + rotl32(v1, 7)) | 0) + rotl32(v2, 12)) | 0) +
+                        rotl32(v3, 18)) |
+                        0) +
+                        len) |
+                    0;
+                for (; ((i + 3) | 0) < len; i = (i + 4) | 0)
+                    h = Math.imul(
+                        rotl32((h + Math.imul(getUint32(buf, i), 0xc2b2ae3d)) | 0, 17),
+                        0x27d4eb2f
+                    );
+            } else {
+                const view = new DataView(buf.buffer);
+                for (; ((i + 15) | 0) < len; i = (i + 16) | 0) {
+                    v0 = Math.imul(
+                        rotl32(
+                            (v0 + Math.imul(view.getUint32((i + 0) | 0, true), 0x85ebca77)) | 0,
+                            13
+                        ),
+                        0x9e3779b1
+                    );
+                    v1 = Math.imul(
+                        rotl32(
+                            (v1 + Math.imul(view.getUint32((i + 4) | 0, true), 0x85ebca77)) | 0,
+                            13
+                        ),
+                        0x9e3779b1
+                    );
+                    v2 = Math.imul(
+                        rotl32(
+                            (v2 + Math.imul(view.getUint32((i + 8) | 0, true), 0x85ebca77)) | 0,
+                            13
+                        ),
+                        0x9e3779b1
+                    );
+                    v3 = Math.imul(
+                        rotl32(
+                            (v3 + Math.imul(view.getUint32((i + 12) | 0, true), 0x85ebca77)) | 0,
+                            13
+                        ),
+                        0x9e3779b1
+                    );
+                }
+
+                h =
+                    (((((((rotl32(v0, 1) + rotl32(v1, 7)) | 0) + rotl32(v2, 12)) | 0) +
+                        rotl32(v3, 18)) |
+                        0) +
+                        len) |
+                    0;
+                for (; ((i + 3) | 0) < len; i = (i + 4) | 0)
+                    h = Math.imul(
+                        rotl32((h + Math.imul(view.getUint32(i, true), 0xc2b2ae3d)) | 0, 17),
+                        0x27d4eb2f
+                    );
+            }
+        }
+
+        for (; i < len; i = (i + 1) | 0)
+            h = Math.imul(rotl32((h + Math.imul(buf[i], 0x165667b1)) | 0, 11), 0x9e3779b1);
+        h = Math.imul(h ^ (h >>> 15), 0x85ebca77);
+        h = Math.imul(h ^ (h >>> 13), 0xc2b2ae3d);
+
+        const c = 'go' + ((h ^ (h >>> 16)) >>> 0).toString(36);
+    })
+    .on('start', function (e) {
+        console.log('\nStarting', e.currentTarget.name);
+    })
+    .on('error', (e) => console.log(e))
+    .on('cycle', function (event) {
+        console.log('▸', String(event.target));
+    })
+    .on('complete', function () {
+        const fastest = this.filter('fastest').map('name')[0];
+        console.log('\nFastest is: ' + fastest);
+    })
+    .run();


### PR DESCRIPTION
This is related and in response of https://github.com/emotion-js/emotion/pull/3241

cc @romgrk

The weird part -- but kinda expected -- was that on node `18.17.0` goober is constantly second but then drops with newer versions.

```
~/work/github/js-benchmark (master*) $ node ./index.js ./benchmarks/hashing.js 
### node: v18.17.0 ###
CASE: murmur2_unmodified: #########################.........................   50.17% (301 ops) (3.326 ms/op)
CASE: murmur2:            ######################################............   76.17% (457 ops) (2.190 ms/op)
CASE: xxh:                ##################################################  100.00% (600 ops) (1.667 ms/op)
CASE: fnv-1a:             #####################################.............   74.83% (449 ops) (2.227 ms/op)
CASE: djb2a:              ##########################################........   85.67% (514 ops) (1.946 ms/op)
CASE: goober_unmodified:  ############################################......   89.67% (538 ops) (1.861 ms/op)

~/work/github/js-benchmark (master*) $ nvm use v18.18.0 
Now using node v18.18.0 (npm v9.8.1)

~/work/github/js-benchmark (master*) $ node ./index.js ./benchmarks/hashing.js 
### node: v18.18.0 ###
CASE: murmur2_unmodified: #######################...........................   46.71% (298 ops) (3.356 ms/op)
CASE: murmur2:            ######################################............   77.74% (496 ops) (2.016 ms/op)
CASE: xxh:                ##################################################  100.00% (638 ops) (1.567 ms/op)
CASE: fnv-1a:             ###################################...............   71.16% (454 ops) (2.205 ms/op)
CASE: djb2a:              ########################################..........   81.19% (518 ops) (1.932 ms/op)
CASE: goober_unmodified:  ######################################............   77.43% (494 ops) (2.024 ms/op)
```

Besides that it really is peculiar what is happening on `bun` that runs so slow?!

Anyway, I've copy/pasted the xxh on goober's hash perf test, and these are the results:

```
node v22.7.0
~/work/github/goober (explore-xxh-algo-and-benchmark*) $ npm run test-perf-hash

> goober@2.1.14 test-perf-hash
> NODE_ENV=production node benchmarks/perf-hash.cjs


Starting HASH!
▸ goober original HASH x 2,830,730 ops/sec ±0.81% (94 runs sampled)
▸ goober optimized HASH x 12,688,564 ops/sec ±3.04% (88 runs sampled)
▸ goober optimized HASH with ASM hints x 13,045,723 ops/sec ±2.04% (92 runs sampled)
▸ twind HASH x 2,617,884 ops/sec ±2.34% (93 runs sampled)
▸ xxh x 6,105,582 ops/sec ±0.49% (93 runs sampled)

Fastest is: goober optimized HASH with ASM hints
```

and
 
```
node v18.17.0
~/work/github/goober (explore-xxh-algo-and-benchmark*) $ npm run test-perf-hash

> goober@2.1.14 test-perf-hash
> NODE_ENV=production node benchmarks/perf-hash.cjs


Starting HASH!
▸ goober original HASH x 2,735,026 ops/sec ±3.08% (89 runs sampled)
▸ goober optimized HASH x 13,061,639 ops/sec ±0.89% (90 runs sampled)
▸ goober optimized HASH with ASM hints x 12,969,513 ops/sec ±1.12% (92 runs sampled)
▸ twind HASH x 2,653,173 ops/sec ±0.68% (93 runs sampled)
▸ xxh x 6,017,804 ops/sec ±0.73% (90 runs sampled)

Fastest is: goober optimized HASH
```

You can find these addition on this branch: https://github.com/cristianbote/goober/compare/master...explore-xxh-algo-and-benchmark

Looking forward to your thoughts