### PR TITLE
Fix goober running in vitest

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -7,7 +7,7 @@ import { getSheet } from './core/get-sheet';
  * @param {String|Object|Function} val
  */
 function css(val) {
-    let ctx = this || {};
+    let ctx = Object.isExtensible(this) ? this : {};;
     let _val = val.call ? val(ctx.p) : val;
 
     return hash(

--- a/src/styled.js
+++ b/src/styled.js
@@ -18,7 +18,7 @@ function setup(pragma, prefix, theme, forwardProps) {
  * @param {function} forwardRef
  */
 function styled(tag, forwardRef) {
-    let _ctx = this || {};
+    let _ctx = Object.isExtensible(this) ? this : {};
 
     return function wrapper() {
         let _args = arguments;


### PR DESCRIPTION
Prevents an error when importing a component using goober into a vitest unit test
```
TypeError: Cannot add property p, object is not extensible
 ❯ a node_modules/goober/dist/goober.modern.js:1:2084
```

The error is happening because `this` is equivalent to `module.exports`
```
console.log(this);

[Module: null prototype] {
  css: [Function: u],
  extractCss: [Function: r],
  glob: [Function: bound u],
  keyframes: [Function: bound u],
  setup: [Function: m],
  styled: [Function: j]
}
```

Reproducible example of the error: https://github.com/hpinkos/vitest-goober