### PR TITLE
refactor(toHash): reduce size by using spread operator and Array.reduce

### DIFF
--- a/src/core/to-hash.js
+++ b/src/core/to-hash.js
@@ -7,9 +7,5 @@
  * @param {String} str
  * @returns {String}
  */
-export let toHash = (str) => {
-    let i = 0,
-        out = 11;
-    while (i < str.length) out = (101 * out + str.charCodeAt(i++)) >>> 0;
-    return 'go' + out;
-};
+export let toHash = (str) =>
+    'go' + [...str].reduce((out, char) => (101 * out + char.charCodeAt(0)) >>> 0, 11);


### PR DESCRIPTION
Spreading the string into an array and using Array.reduce instead of a while loop seems to shave off 9 Bytes of the toHash function. :)