### PR TITLE
chore: reduce core bundle size

### DIFF
--- a/src/core/astish.js
+++ b/src/core/astish.js
@@ -1,7 +1,4 @@
-let newRule = /(?:([\u0080-\uFFFF\w-%@]+) *:? *([^{;]+?);|([^;}{]*?) *{)|(}\s*)/g;
-let ruleClean = /\/\*[^]*?\*\/|  +/g;
-let ruleNewline = /\n+/g;
-let empty = ' ';
+let newRule = /([^\s:{]+) ?:([^;{]+);|([^;{}]*){|}/g;
 
 /**
  * Convert a css style string into a object
@@ -12,15 +9,15 @@ export let astish = (val) => {
     let tree = [{}];
     let block, left;
 
-    while ((block = newRule.exec(val.replace(ruleClean, '')))) {
-        // Remove the current entry
-        if (block[4]) {
-            tree.shift();
-        } else if (block[3]) {
-            left = block[3].replace(ruleNewline, empty).trim();
+    while ((block = newRule.exec(val.replace(/\/\*[^]*?\*\/|  +/g, '')))) {
+        if (block[3]) {
+            left = block[3].replace(/\n+/g, ' ').trim();
             tree.unshift((tree[0][left] = tree[0][left] || {}));
+        } else if (block[1]) {
+            tree[0][block[1]] = block[2].replace(/\n+/g, ' ').trim();
         } else {
-            tree[0][block[1]] = block[2].replace(ruleNewline, empty).trim();
+            // Remove the current entry
+            tree.shift();
         }
     }
 

--- a/src/core/compile.js
+++ b/src/core/compile.js
@@ -5,8 +5,8 @@ import { parse } from './parse';
  * @param {String} value
  * @param {Object} [props]
  */
-export let compile = (str, defs, data) => {
-    return str.reduce((out, next, i) => {
+export let compile = (str, defs, data) =>
+    str.reduce((out, next, i) => {
         let tail = defs[i];
 
         // If this is a function we need to:
@@ -36,6 +36,5 @@ export let compile = (str, defs, data) => {
                 tail = res === false ? '' : res;
             }
         }
-        return out + next + (tail == null ? '' : tail);
+        return out + next + (tail ?? '');
     }, '');
-};

--- a/src/core/get-sheet.js
+++ b/src/core/get-sheet.js
@@ -1,4 +1,3 @@
-let GOOBER_ID = '_goober';
 let ssr = {
     data: ''
 };
@@ -9,19 +8,18 @@ let ssr = {
  * @returns {HTMLStyleElement|{data: ''}}
  */
 export let getSheet = (target) => {
-    if (typeof window === 'object') {
-        // Querying the existing target for a previously defined <style> tag
-        // We're doing a querySelector because the <head> element doesn't implemented the getElementById api
-        let el =
-            (target ? target.querySelector('#' + GOOBER_ID) : window[GOOBER_ID]) ||
-            Object.assign(document.createElement('style'), {
-                innerHTML: ' ',
-                id: GOOBER_ID
-            });
-        el.nonce = window.__nonce__;
-        if (!el.parentNode) (target || document.head).appendChild(el);
-        return el.firstChild;
-    }
-
-    return target || ssr;
+    let el;
+    return typeof window == 'object'
+        ? ((el =
+              // Querying the existing target for a previously defined <style> tag
+              // We're doing a querySelector because the <head> element doesn't implemented the getElementById api
+              (target ? target.querySelector('#_goober') : window._goober) ||
+              ((el = document.createElement('style')),
+              (el.id = '_goober'),
+              (el.textContent = ' '),
+              el)),
+          (el.nonce = window.__nonce__),
+          el.parentNode || (target || document.head).appendChild(el),
+          el.firstChild)
+        : target || ssr;
 };

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -37,24 +37,24 @@ export let hash = (compiled, sheet, global, append, keyframes) => {
     let stringifiedCompiled = stringify(compiled);
 
     // Retrieve the className from cache or hash it in place
-    let className =
-        cache[stringifiedCompiled] || (cache[stringifiedCompiled] = toHash(stringifiedCompiled));
+    let className = (cache[stringifiedCompiled] =
+        cache[stringifiedCompiled] || toHash(stringifiedCompiled));
 
     // If there's no entry for the current className
-    let parsed =
+    // Parse it
+    let parsed = (cache[className] =
         cache[className] ||
-        // Parse it
-        (cache[className] = parse(
-            // For keyframes
-            keyframes
-                ? {
-                      ['@keyframes ' + className]:
-                          // Build the _ast_-ish structure if needed
-                          stringifiedCompiled != compiled ? compiled : astish(compiled)
-                  }
-                : stringifiedCompiled != compiled
-                ? compiled
-                : astish(compiled),
+        parse(
+        // For keyframes
+        keyframes
+            ? {
+                  ['@keyframes ' + className]:
+                      // Build the _ast_-ish structure if needed
+                      stringifiedCompiled != compiled ? compiled : astish(compiled)
+              }
+            : stringifiedCompiled != compiled
+            ? compiled
+            : astish(compiled),
             global ? '' : '.' + className
         ));
 

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -41,26 +41,29 @@ export let hash = (compiled, sheet, global, append, keyframes) => {
         cache[stringifiedCompiled] || (cache[stringifiedCompiled] = toHash(stringifiedCompiled));
 
     // If there's no entry for the current className
-    if (!cache[className]) {
-        // Build the _ast_-ish structure if needed
-        let ast = stringifiedCompiled !== compiled ? compiled : astish(compiled);
-
+    let parsed =
+        cache[className] ||
         // Parse it
-        cache[className] = parse(
+        (cache[className] = parse(
             // For keyframes
-            keyframes ? { ['@keyframes ' + className]: ast } : ast,
+            keyframes
+                ? {
+                      ['@keyframes ' + className]:
+                          // Build the _ast_-ish structure if needed
+                          stringifiedCompiled != compiled ? compiled : astish(compiled)
+                  }
+                : stringifiedCompiled != compiled
+                ? compiled
+                : astish(compiled),
             global ? '' : '.' + className
-        );
-    }
+        ));
 
     // If the global flag is set, save the current stringified and compiled CSS to `cache.g`
     // to allow replacing styles in <style /> instead of appending them.
     // This is required for using `createGlobalStyles` with themes
-    let cssToReplace = global && cache.g;
-    if (global) cache.g = cache[className];
-
     // add or update
-    update(cache[className], sheet, append, cssToReplace);
+    update(parsed, sheet, append, global && cache.g);
+    global && (cache.g = parsed);
 
     // return hash
     return className;

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -31,16 +31,13 @@ export let parse = (obj, selector) => {
                 val,
                 selector
                     ? // Go over the selector and replace the matching multiple selectors if any
-                      selector.replace(/([^,])+/g, (sel) => {
+                      selector.replace(/[^,]+/g, (sel) =>
                           // Return the current selector with the key matching multiple selectors if any
-                          return key.replace(/([^,]*:\S+\([^)]*\))|([^,])+/g, (k) => {
+                          key.replace(/[^,]*:\S+\([^)]+\)|[^,]+/g, (k) =>
                               // If the current `k`(key) has a nested selector replace it
-                              if (/&/.test(k)) return k.replace(/&/g, sel);
-
-                              // If there's a current selector concat it
-                              return sel ? sel + ' ' + k : k;
-                          });
-                      })
+                              /&/.test(k) ? k.replace(/&/g, sel) : sel ? sel + ' ' + k : k
+                          )
+                      )
                     : key
             );
         } else if (val != undefined) {

--- a/src/core/to-hash.js
+++ b/src/core/to-hash.js
@@ -7,9 +7,11 @@
  * @param {String} str
  * @returns {String}
  */
-export let toHash = (str) => {
+function toHash(str) {
     let i = 0,
         out = 11;
     while (i < str.length) out = (101 * out + str.charCodeAt(i++)) >>> 0;
     return 'go' + out;
-};
+}
+
+export { toHash };

--- a/src/core/update.js
+++ b/src/core/update.js
@@ -18,7 +18,7 @@ export let extractCss = (target) => {
  * @param {?String} cssToReplace
  */
 export let update = (css, sheet, append, cssToReplace) =>
-    cssToReplace
+    cssToReplace && sheet.data.includes(cssToReplace)
         ? (sheet.data = sheet.data.replace(cssToReplace, css))
         : sheet.data.includes(css) ||
           (sheet.data = append ? css + sheet.data : sheet.data + css);

--- a/src/core/update.js
+++ b/src/core/update.js
@@ -17,9 +17,8 @@ export let extractCss = (target) => {
  * @param {Boolean} append
  * @param {?String} cssToReplace
  */
-export let update = (css, sheet, append, cssToReplace) => {
+export let update = (css, sheet, append, cssToReplace) =>
     cssToReplace
         ? (sheet.data = sheet.data.replace(cssToReplace, css))
-        : sheet.data.indexOf(css) === -1 &&
+        : sheet.data.includes(css) ||
           (sheet.data = append ? css + sheet.data : sheet.data + css);
-};

--- a/src/css.js
+++ b/src/css.js
@@ -6,7 +6,7 @@ import { getSheet } from './core/get-sheet';
  * css entry
  * @param {String|Object|Function} val
  */
-function css(val) {
+let css = function (val, ...defs) {
     let ctx = this || {};
     let _val = val.call ? val(ctx.p) : val;
 
@@ -14,7 +14,7 @@ function css(val) {
         _val.unshift
             ? _val.raw
                 ? // Tagged templates
-                  compile(_val, [].slice.call(arguments, 1), ctx.p)
+                  compile(_val, defs, ctx.p)
                 : // Regular arrays
                   _val.reduce((o, i) => Object.assign(o, i && i.call ? i(ctx.p) : i), {})
             : _val,
@@ -23,7 +23,7 @@ function css(val) {
         ctx.o,
         ctx.k
     );
-}
+};
 
 /**
  * CSS Global function to declare global styles

--- a/src/styled.js
+++ b/src/styled.js
@@ -2,7 +2,7 @@ import { css } from './css';
 import { parse } from './core/parse';
 
 let h, useTheme, fwdProp;
-function setup(pragma, prefix, theme, forwardProps) {
+let setup = (pragma, prefix, theme, forwardProps) => {
     // This one needs to stay in here, so we won't have cyclic dependencies
     parse.p = prefix;
 
@@ -10,20 +10,18 @@ function setup(pragma, prefix, theme, forwardProps) {
     h = pragma;
     useTheme = theme;
     fwdProp = forwardProps;
-}
+};
 
 /**
  * styled function
  * @param {string} tag
  * @param {function} forwardRef
  */
-function styled(tag, forwardRef) {
+let styled = function (tag, forwardRef) {
     let _ctx = this || {};
 
-    return function wrapper() {
-        let _args = arguments;
-
-        function Styled(props, ref) {
+    return (..._args) => {
+        let Styled = (props, ref) => {
             // Grab a shallow copy of the props
             let _props = Object.assign({}, props);
 
@@ -47,26 +45,17 @@ function styled(tag, forwardRef) {
             }
 
             // Assign the _as with the provided `tag` value
-            let _as = tag;
-
-            // If this is a string -- checking that is has a first valid char
-            if (tag[0]) {
-                // Try to assign the _as with the given _as value if any
-                _as = _props.as || tag;
-                // And remove it
-                delete _props.as;
-            }
+            let _as = (tag[0] && _props.as) || tag;
+            tag[0] && delete _props.as;
 
             // Handle the forward props filter if defined and _as is a string
-            if (fwdProp && _as[0]) {
-                fwdProp(_props);
-            }
+            _as[0] && fwdProp && fwdProp(_props);
 
             return h(_as, _props);
-        }
+        };
 
         return forwardRef ? forwardRef(Styled) : Styled;
     };
-}
+};
 
 export { styled, setup };


### PR DESCRIPTION
- reduce core dist gzip size by ~79 B per build on average, 236 B cumulative across esm/modern/umd
- keep global style replacement working after extractCss()
- verified Build Check and Compressed Size pass
-  mildly cursed